### PR TITLE
Use auto-dismiss toast for saved transaction feedback

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -139,7 +139,7 @@ struct InputView: View {
     @State private var selectedCategory: Category?
     @State private var selectedMethod: PaymentMethod?
     @State private var note = ""
-    @State private var showSavedCheck = false
+    @State private var showSavedToast = false
 
     var body: some View {
         NavigationStack {
@@ -210,7 +210,19 @@ struct InputView: View {
             .task {
                 if categories.isEmpty || methods.isEmpty { seedDefaults() }
             }
-            .alert("Saved ✔︎", isPresented: $showSavedCheck) { Button("OK", role: .cancel) { } }
+            .overlay(alignment: .top) {
+                if showSavedToast {
+                    Text("Saved ✔︎")
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color.black.opacity(0.8))
+                        .foregroundStyle(.white)
+                        .cornerRadius(8)
+                        .padding(.top)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.default, value: showSavedToast)
         }
     }
 
@@ -252,7 +264,10 @@ struct InputView: View {
         amountText = ""
         note = ""
         date = Date()
-        showSavedCheck = true
+        withAnimation { showSavedToast = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { showSavedToast = false }
+        }
 
         // Make sure the keyboard is down after save too
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)


### PR DESCRIPTION
## Summary
- show a temporary "Saved" toast at the top of the Input view instead of an alert
- automatically hide the toast after 2 seconds

## Testing
- ⚠️ `swift build` *(Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c30b87f36c83219ac757d2769a10e9