### PR TITLE
Resolve circular Relationship macro errors

### DIFF
--- a/Models.swift
+++ b/Models.swift
@@ -59,9 +59,7 @@ final class Transaction {
     // Use nullify delete rules so that if the related Category or PaymentMethod
     // is deleted, existing transactions simply lose the reference instead of
     // crashing when their properties are accessed.
-    @Relationship(deleteRule: .nullify, inverse: \Category.transactions)
     var category: Category?
-    @Relationship(deleteRule: .nullify, inverse: \PaymentMethod.transactions)
     var paymentMethod: PaymentMethod?
     /// Stable ID used when syncing to Google Sheets (and future backends).
     var remoteID: String


### PR DESCRIPTION
## Summary
- Drop redundant `@Relationship` annotations from `Transaction` model to avoid circular macro expansion
- Keep inverse relationships defined on `Category` and `PaymentMethod` to maintain nullify delete rules

## Testing
- `swiftc Models.swift` *(fails: no such module 'SwiftData')*

------
https://chatgpt.com/codex/tasks/task_e_68c30f47111883218791ae1cbeb83f4d