### PR TITLE
Support income categories with signed transactions

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -201,7 +201,7 @@ struct InputView: View {
                 // SAVE BUTTON
                 Section {
                     Button(action: save) {
-                        HStack { Spacer(); Text("Save expense").fontWeight(.semibold); Spacer() }
+                        HStack { Spacer(); Text("Save entry").fontWeight(.semibold); Spacer() }
                     }
                     .disabled(!canSave)
                 }
@@ -239,8 +239,10 @@ struct InputView: View {
     private func save() {
         guard let amount = amountDecimal else { return }
 
+        let signedAmount = (selectedCategory?.isIncome ?? false) ? amount : -amount
+
         let tx = Transaction(
-            amount: amount,
+            amount: signedAmount,
             date: date,
             note: note.isEmpty ? nil : note,
             category: selectedCategory,
@@ -253,7 +255,7 @@ struct InputView: View {
         // If you wired Google Sheets:
         SHEETS.postTransaction(
             remoteID: tx.remoteID,
-            amount: amount,
+            amount: signedAmount,
             date: date,
             categoryName: selectedCategory?.name,
             paymentName: selectedMethod?.name,

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -17,6 +17,7 @@ struct ManageView: View {
 
     @State private var newCategory = ""
     @State private var newCategoryEmoji = ""
+    @State private var newCategoryIsIncome = false
     @State private var newPayment = ""
     @State private var alertMessage: String?
     @FocusState private var focusedField: Field?
@@ -37,6 +38,8 @@ struct ManageView: View {
                                 Text(c.emoji ?? "🏷️")
                                 Text(c.name)
                                 Spacer()
+                                Text(c.isIncome ? "+" : "-")
+                                    .foregroundStyle(c.isIncome ? .green : .red)
                                 Button(role: .destructive) {
                                     context.delete(c)
                                     try? context.save()
@@ -65,6 +68,11 @@ struct ManageView: View {
                                 .frame(maxWidth: 120)
                                 .focused($focusedField, equals: .catEmoji)
                         }
+                        Picker("Type", selection: $newCategoryIsIncome) {
+                            Text("Expense").tag(false)
+                            Text("Income").tag(true)
+                        }
+                        .pickerStyle(.segmented)
                         Button("Add category", action: addCategory)
                             .disabled(trimmed(newCategory).isEmpty)
                     }
@@ -132,7 +140,12 @@ struct ManageView: View {
         }
 
         let next = (categories.map { $0.sortIndex }.max() ?? -1) + 1
-        let newCat = Category(name: name, emoji: emoji.isEmpty ? nil : emoji, sortIndex: next)
+        let newCat = Category(
+            name: name,
+            emoji: emoji.isEmpty ? nil : emoji,
+            sortIndex: next,
+            isIncome: newCategoryIsIncome
+        )
 
         context.insert(newCat)
         do {
@@ -143,10 +156,11 @@ struct ManageView: View {
                 remoteID: newCat.remoteID,
                 name: newCat.name,
                 emoji: newCat.emoji,
-                sortIndex: newCat.sortIndex
+                sortIndex: newCat.sortIndex,
+                isIncome: newCat.isIncome
             )
 
-            newCategory = ""; newCategoryEmoji = ""
+            newCategory = ""; newCategoryEmoji = ""; newCategoryIsIncome = false
             focusedField = .catName
         } catch {
             alertMessage = "Could not save category: \(error.localizedDescription)"

--- a/Models.swift
+++ b/Models.swift
@@ -9,6 +9,8 @@ final class Category {
     var sortIndex: Int
     /// Stable ID used when syncing to Google Sheets (and future backends).
     var remoteID: String
+    /// Whether transactions in this category should be treated as income (positive values).
+    var isIncome: Bool
     /// Transactions assigned to this category.
     /// If the category is removed, existing transactions should keep their data
     /// and simply become uncategorized rather than crashing when accessed.
@@ -19,12 +21,14 @@ final class Category {
         name: String,
         emoji: String? = nil,
         sortIndex: Int = 0,
-        remoteID: String = UUID().uuidString
+        remoteID: String = UUID().uuidString,
+        isIncome: Bool = false
     ) {
         self.name = name
         self.emoji = emoji
         self.sortIndex = sortIndex
         self.remoteID = remoteID
+        self.isIncome = isIncome
     }
 }
 

--- a/SheetsClient.swift
+++ b/SheetsClient.swift
@@ -25,13 +25,15 @@ struct SheetsClient {
     }
 
     func postCategory(remoteID: String, name: String, emoji: String?, sortIndex: Int,
+                      isIncome: Bool,
                       completion: @escaping (Response) -> Void = { _ in }) {
         let payload: [String: Any] = [
             "type": "category",
             "remoteID": remoteID,
             "name": name,
             "emoji": emoji ?? "",
-            "sortIndex": sortIndex
+            "sortIndex": sortIndex,
+            "isIncome": isIncome
         ]
         postJSON(payload, completion: completion)
     }


### PR DESCRIPTION
## Summary
- Allow categories to be marked as income or expense
- Treat transaction amounts as positive or negative based on selected category
- Include category type when syncing to Google Sheets

## Testing
- `swiftc *.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68c31559f67c8321a4a0b0309bd3968b