### PR TITLE
Ensure model saves occur on main actor

### DIFF
--- a/ManageView.swift
+++ b/ManageView.swift
@@ -152,13 +152,12 @@ struct ManageView: View {
             isIncome: newCategoryIsIncome
         )
 
-        withAnimation {
-            context.insert(newCat)
-        }
         do {
-            try context.save()
+            try withAnimation {
+                context.insert(newCat)
+                try context.save()
+            }
 
-            // 🔄 Push to Google Sheets
             SHEETS.postCategory(
                 remoteID: newCat.remoteID,
                 name: newCat.name,
@@ -188,13 +187,12 @@ struct ManageView: View {
         let next = (methods.map { $0.sortIndex }.max() ?? -1) + 1
         let newPM = PaymentMethod(name: name, sortIndex: next)
 
-        withAnimation {
-            context.insert(newPM)
-        }
         do {
-            try context.save()
+            try withAnimation {
+                context.insert(newPM)
+                try context.save()
+            }
 
-            // 🔄 Push to Google Sheets
             SHEETS.postPayment(
                 remoteID: newPM.remoteID,
                 name: newPM.name,


### PR DESCRIPTION
## Summary
- run input and management saves on the main actor
- surface save errors with alerts while keeping toast feedback

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c34c6e19a883219ebc081a35ecaeb1