### PR TITLE
Add category types and display income/expense totals

### DIFF
--- a/HistoryView.swift
+++ b/HistoryView.swift
@@ -25,9 +25,19 @@ struct HistoryView: View {
                     // Monthly total section (current month)
                     Section("This month") {
                         HStack {
-                            Text("Total")
+                            Text("Income")
                             Spacer()
-                            Text(totalThisMonth as NSNumber, formatter: currencyFormatter)
+                            Text(incomeThisMonth as NSNumber, formatter: currencyFormatter)
+                        }
+                        HStack {
+                            Text("Expenses")
+                            Spacer()
+                            Text(expensesThisMonth as NSNumber, formatter: currencyFormatter)
+                        }
+                        HStack {
+                            Text("Net")
+                            Spacer()
+                            Text(netThisMonth as NSNumber, formatter: currencyFormatter)
                                 .fontWeight(.semibold)
                         }
                     }
@@ -76,14 +86,22 @@ struct HistoryView: View {
         try? context.save()
     }
 
-    private var totalThisMonth: Decimal {
+    private var thisMonthTransactions: [Transaction] {
         let cal = Calendar.current
         let startOfMonth = cal.date(from: cal.dateComponents([.year, .month], from: Date())) ?? Date()
         let startNext = cal.date(byAdding: .month, value: 1, to: startOfMonth) ?? Date()
-        return txs
-            .filter { $0.date >= startOfMonth && $0.date < startNext }
-            .reduce(0) { $0 + $1.amount }
+        return txs.filter { $0.date >= startOfMonth && $0.date < startNext }
     }
+
+    private var incomeThisMonth: Decimal {
+        thisMonthTransactions.reduce(0) { $0 + max($1.amount, 0) }
+    }
+
+    private var expensesThisMonth: Decimal {
+        thisMonthTransactions.reduce(0) { $0 + min($1.amount, 0) }
+    }
+
+    private var netThisMonth: Decimal { incomeThisMonth + expensesThisMonth }
 
     // Currency & date formatters
     private var currencyFormatter: NumberFormatter {

--- a/InputView.swift
+++ b/InputView.swift
@@ -293,14 +293,18 @@ struct InputView: View {
                               paymentsOnly: Bool = false) {
         if !paymentsOnly && categories.isEmpty {
             let base = (categories.map { $0.sortIndex }.max() ?? -1) + 1
-            let seeds: [(String, String?)] = [
-                ("Food", "🍽️"), ("Transport", "🚕"),
-                ("Bills", "💡"), ("Shopping", "🛍️"),
-                ("Leisure", "🎬")
+            let seeds: [(String, String?, Bool)] = [
+                ("Food", "🍽️", false),
+                ("Transport", "🚕", false),
+                ("Bills", "💡", false),
+                ("Shopping", "🛍️", false),
+                ("Leisure", "🎬", false),
+                ("Salary", "💼", true),
+                ("Gifts", "🎁", true)
             ]
-            for (offset, pair) in seeds.enumerated() {
-                let (name, emoji) = pair
-                context.insert(Category(name: name, emoji: emoji, sortIndex: base + offset))
+            for (offset, seed) in seeds.enumerated() {
+                let (name, emoji, isIncome) = seed
+                context.insert(Category(name: name, emoji: emoji, sortIndex: base + offset, isIncome: isIncome))
             }
         }
         if !categoriesOnly && methods.isEmpty {

--- a/SummaryView.swift
+++ b/SummaryView.swift
@@ -35,11 +35,21 @@ struct SummaryView: View {
                     .pickerStyle(.menu)
                 }
 
-                Section(header: Text("Total")) {
+                Section(header: Text("Totals")) {
                     HStack {
-                        Text("\(shortMonthName(selectedMonth)) \(String(selectedYear))")
+                        Text("Income")
                         Spacer()
-                        Text(formatCurrency(totalForSelection))
+                        Text(formatCurrency(totalIncome))
+                    }
+                    HStack {
+                        Text("Expenses")
+                        Spacer()
+                        Text(formatCurrency(totalExpenses))
+                    }
+                    HStack {
+                        Text("Net")
+                        Spacer()
+                        Text(formatCurrency(netTotal))
                             .fontWeight(.semibold)
                     }
                 }
@@ -94,9 +104,15 @@ struct SummaryView: View {
         return txs.filter { $0.date >= start && $0.date < end }
     }
 
-    private var totalForSelection: Decimal {
-        filteredTxs.reduce(0) { $0 + $1.amount }
+    private var totalIncome: Decimal {
+        filteredTxs.reduce(0) { $0 + max($1.amount, 0) }
     }
+
+    private var totalExpenses: Decimal {
+        filteredTxs.reduce(0) { $0 + min($1.amount, 0) }
+    }
+
+    private var netTotal: Decimal { totalIncome + totalExpenses }
 
     private var byCategory: [String: Decimal] {
         var dict: [String: Decimal] = [:]


### PR DESCRIPTION
## Summary
- allow seeding and adding categories as income or expense, with sample income categories
- show income, expenses and net totals in summary and history views

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c3562ebf808321af1d8232865cf09e