### PR TITLE
Improve keyboard interactions and emoji input

### DIFF
--- a/UIHelpers.swift
+++ b/UIHelpers.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+func dismissKeyboard() {
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+}


### PR DESCRIPTION
## Summary
- Add reusable AccessoryTextField with emoji keyboard option
- Use accessory text fields for category and payment inputs and dismiss keyboard on taps
- Automatically collapse date picker and hide keyboards when interacting elsewhere

## Testing
- `swiftc *.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68c35c1575688321a406b3b3f99e2966