### PR TITLE
Update onChange for iOS 17 and declare no app encryption

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
+</dict>
+</plist>

--- a/InputView.swift
+++ b/InputView.swift
@@ -174,7 +174,7 @@ struct InputView: View {
                 // DATE
                 Section("Date") {
                     DatePicker("When", selection: $date, displayedComponents: .date)
-                        .onChange(of: date) { _ in dismissKeyboard() }
+                        .onChange(of: date) { dismissKeyboard() }
                 }
 
                 // PAYMENT TYPE


### PR DESCRIPTION
## Summary
- use new closure syntax for SwiftUI `onChange` in `InputView`
- specify `ITSAppUsesNonExemptEncryption` false in Info.plist so App Store Connect knows the app doesn't use encryption

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc InputView.swift -o /tmp/InputView && /tmp/InputView` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68c35f5ba8048321aa8beb6f21824004