### PR TITLE
Use explicit Color for toast overlay text

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -211,7 +211,7 @@ struct InputView: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
                 .background(Color.appSecondaryBackground.opacity(0.8))
-                .foregroundStyle(.appText)
+                .foregroundStyle(Color.appText)
                 .cornerRadius(8)
                 .padding(.top)
                 .transition(.move(edge: .top).combined(with: .opacity))


### PR DESCRIPTION
## Summary
- Fix `foregroundStyle` call in `InputView` to reference `Color.appText` explicitly

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c36dc993c48321a3897addbc4bb0fd