### PR TITLE
Qualify appAccent usage in foregroundStyle

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -295,7 +295,7 @@ struct InputView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.gray.opacity(0.3))
-            .foregroundStyle(.appAccent)
+            .foregroundStyle(Color.appAccent)
             .disabled(!canSave)
         }
     }

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -123,7 +123,7 @@ struct ManageView: View {
                     Button("Add category", action: addCategory)
                         .buttonStyle(.borderedProminent)
                         .tint(.gray.opacity(0.3))
-                        .foregroundStyle(.appAccent)
+                        .foregroundStyle(Color.appAccent)
                         .disabled(trimmed(newCategory).isEmpty)
                 }
                 .transition(.opacity)
@@ -182,7 +182,7 @@ struct ManageView: View {
                     Button("Add", action: addPayment)
                         .buttonStyle(.borderedProminent)
                         .tint(.gray.opacity(0.3))
-                        .foregroundStyle(.appAccent)
+                        .foregroundStyle(Color.appAccent)
                         .disabled(trimmed(newPayment).isEmpty)
                 }
                 .transition(.opacity)


### PR DESCRIPTION
## Summary
- Fix compile errors by explicitly qualifying `appAccent` with `Color` when used in `foregroundStyle`

## Testing
- `swiftc -typecheck InputView.swift ManageView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68c373101b508321a6970f4ee05ea8d6