### PR TITLE
Fix picker interactions and category type selector

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -192,7 +192,7 @@ struct InputView: View {
         .scrollContentBackground(.hidden)
         .background(Color.appBackground)
         .listRowBackground(Color.appSecondaryBackground)
-        .onTapGesture { dismissKeyboard() }
+        .simultaneousGesture(TapGesture().onEnded { dismissKeyboard() })
         .task {
             if categories.isEmpty || methods.isEmpty { seedDefaults() }
         }

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -47,7 +47,7 @@ struct ManageView: View {
                 .scrollContentBackground(.hidden)
                 .background(Color.appBackground)
                 .listRowBackground(Color.appSecondaryBackground)
-                .onTapGesture { dismissKeyboard() }
+                .simultaneousGesture(TapGesture().onEnded { dismissKeyboard() })
             }
             .navigationTitle("Manage")
             .toolbar { EditButton() }
@@ -116,10 +116,11 @@ struct ManageView: View {
                     )
                     Picker("Type", selection: $newCategoryIsIncome) {
                         Text("Choose…").tag(Bool?.none)
-                        Text("Expense").tag(Bool?.some(false))
-                        Text("Income").tag(Bool?.some(true))
+                        ForEach([false, true], id: \.self) { isIncome in
+                            Text(isIncome ? "Income" : "Expense")
+                                .tag(Bool?.some(isIncome))
+                        }
                     }
-                    .pickerStyle(.navigationLink)
                     .onChange(of: newCategoryIsIncome) { _ in dismissKeyboard() }
                     Button("Add category", action: addCategory)
                         .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## Summary
- allow pickers to open by not intercepting tap gestures
- match expense/income selector with category picker style

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c376705dac8321b073fdc5958b5539