### PR TITLE
Fix picker interactions by adjusting keyboard dismissal

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -192,7 +192,7 @@ struct InputView: View {
         .scrollContentBackground(.hidden)
         .background(Color.appBackground)
         .listRowBackground(Color.appSecondaryBackground)
-        .simultaneousGesture(TapGesture().onEnded { dismissKeyboard() })
+        .scrollDismissesKeyboard(.interactively)
         .task {
             if categories.isEmpty || methods.isEmpty { seedDefaults() }
         }

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -47,7 +47,7 @@ struct ManageView: View {
                 .scrollContentBackground(.hidden)
                 .background(Color.appBackground)
                 .listRowBackground(Color.appSecondaryBackground)
-                .simultaneousGesture(TapGesture().onEnded { dismissKeyboard() })
+                .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle("Manage")
             .toolbar { EditButton() }


### PR DESCRIPTION
## Summary
- prevent tap gesture from blocking pickers by removing simultaneous tap handling
- use scroll-based keyboard dismissal in InputView and ManageView

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c377c8cec883219c63c025e4d72fae