### PR TITLE
Use theme cyan for save button and auto-close date picker

### DIFF
--- a/InputView.swift
+++ b/InputView.swift
@@ -240,7 +240,11 @@ struct InputView: View {
     @ViewBuilder private var dateSection: some View {
         Section("Date") {
             DatePicker("When", selection: $date, displayedComponents: .date)
-                .onChange(of: date) { _ in dismissKeyboard() }
+                .onChange(of: date) { _ in
+                    DispatchQueue.main.async {
+                        dismissKeyboard()
+                    }
+                }
         }
     }
 
@@ -295,7 +299,7 @@ struct InputView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(Color.appSecondaryBackground)
-            .foregroundColor(.cyan)
+            .foregroundColor(Color.appAccent)
             .disabled(!canSave)
         }
     }


### PR DESCRIPTION
## Summary
- Close the calendar once a date is picked by dismissing focus on change
- Tint the Save button text with the app accent cyan (#00FFFF)

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ce29278832193f3d1c2de4bfc46