### PR TITLE
Align bottom tab bar with input field margins

### DIFF
--- a/HomeTabView.swift
+++ b/HomeTabView.swift
@@ -55,12 +55,13 @@ struct HomeTabView: View {
                     }
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 12)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
             .background(
                 Capsule().fill(Color.appTabBar)
             )
-            .padding(.bottom, 20)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
         }
         .ignoresSafeArea(.keyboard, edges: .bottom)
     }


### PR DESCRIPTION
## Summary
- shrink custom tab bar padding to match input field width
- align bar from screen edges with equal horizontal and bottom spacing

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c382091fd88321ab81190c1ed92064