### PR TITLE
Ensure tab bar distance from bottom matches side margins

### DIFF
--- a/HomeTabView.swift
+++ b/HomeTabView.swift
@@ -63,6 +63,6 @@ struct HomeTabView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 16)
         }
-        .ignoresSafeArea(.keyboard, edges: .bottom)
+        .ignoresSafeArea(.all, edges: .bottom)
     }
 }


### PR DESCRIPTION
## Summary
- Align tab bar offset so bottom spacing matches horizontal margins by ignoring bottom safe area.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c3833c747883219b9025978946d7d4