### PR TITLE
Ensure consistent active tab highlight width

### DIFF
--- a/HomeTabView.swift
+++ b/HomeTabView.swift
@@ -34,7 +34,7 @@ struct HomeTabView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.appBackground)
 
-            HStack {
+            HStack(spacing: 0) {
                 ForEach(Tab.allCases, id: \.self) { tab in
                     Button {
                         selection = tab
@@ -48,11 +48,12 @@ struct HomeTabView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
                         .frame(maxWidth: .infinity)
-                        .foregroundColor(selection == tab ? Color.appBackground : Color.appText)
-                        .background(
-                            Capsule().fill(selection == tab ? Color.appAccent : Color.clear)
-                        )
                     }
+                    .frame(maxWidth: .infinity)
+                    .foregroundColor(selection == tab ? Color.appBackground : Color.appText)
+                    .background(
+                        Capsule().fill(selection == tab ? Color.appAccent : Color.clear)
+                    )
                 }
             }
             .padding(.horizontal, 12)


### PR DESCRIPTION
## Summary
- make each tab button expand equally so the active cyan highlight has uniform width

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c3846e0c7c8321a19dd7c48cf5c5c5