### PR TITLE
Fix selected tab highlight size

### DIFF
--- a/HomeTabView.swift
+++ b/HomeTabView.swift
@@ -48,12 +48,12 @@ struct HomeTabView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
                         .frame(maxWidth: .infinity)
+                        .background(
+                            Capsule().fill(selection == tab ? Color.appAccent : Color.clear),
+                        )
                     }
                     .frame(maxWidth: .infinity)
                     .foregroundColor(selection == tab ? Color.appBackground : Color.appText)
-                    .background(
-                        Capsule().fill(selection == tab ? Color.appAccent : Color.clear)
-                    )
                 }
             }
             .padding(.horizontal, 12)


### PR DESCRIPTION
## Summary
- ensure each tab's active highlight capsule spans the full tab width for consistent sizing

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68c3857caba48321bc44d5cdfccf9a75