### PR TITLE
Fix inconsistent tab capsule height

### DIFF
--- a/HomeTabView.swift
+++ b/HomeTabView.swift
@@ -47,7 +47,7 @@ struct HomeTabView: View {
                         }
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
-                        .frame(width: 80)
+                        .frame(width: 80, height: 48)
                         .background(
                             Capsule().fill(selection == tab ? Color.appAccent : Color.clear)
                         )


### PR DESCRIPTION
## Summary
- Keep tab buttons the same shape by setting a fixed height

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c388353780832190a79055b835828f