### PR TITLE
Align button color and add black headers

### DIFF
--- a/HistoryView.swift
+++ b/HistoryView.swift
@@ -78,6 +78,9 @@ struct HistoryView: View {
             .navigationTitle("History")
             .toolbar { EditButton() } // enables swipe-to-delete / Edit
         }
+        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)

--- a/InputView.swift
+++ b/InputView.swift
@@ -173,6 +173,9 @@ struct InputView: View {
             formContent
                 .navigationTitle("Input")
         }
+        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
@@ -298,7 +301,7 @@ struct InputView: View {
                 HStack { Spacer(); Text("Save entry").fontWeight(.semibold); Spacer() }
             }
             .buttonStyle(.borderedProminent)
-            .tint(Color.appSecondaryBackground)
+            .tint(Color.appTabBar)
             .foregroundColor(Color.appAccent)
             .disabled(!canSave)
         }

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -61,6 +61,9 @@ struct ManageView: View {
                 Text(alertMessage ?? "")
             }
         }
+        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)

--- a/SummaryView.swift
+++ b/SummaryView.swift
@@ -87,6 +87,9 @@ struct SummaryView: View {
             .listRowBackground(Color.appSecondaryBackground)
             .navigationTitle("Summary")
         }
+        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)


### PR DESCRIPTION
## Summary
- Tint Input screen's save button with the tab bar color
- Apply a black toolbar background to Input, History, Summary and Manage screens to highlight their titles

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c38a513b208321a5b92e9afa167fd4