### PR TITLE
Ensure consistent header styling across tabs

### DIFF
--- a/HistoryView.swift
+++ b/HistoryView.swift
@@ -81,6 +81,8 @@ struct HistoryView: View {
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Helpers

--- a/InputView.swift
+++ b/InputView.swift
@@ -176,6 +176,8 @@ struct InputView: View {
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     /// Main form broken out for easier type-checking

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -64,6 +64,8 @@ struct ManageView: View {
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Sections

--- a/SummaryView.swift
+++ b/SummaryView.swift
@@ -90,6 +90,8 @@ struct SummaryView: View {
         .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Filtering for selected month/year


### PR DESCRIPTION
## Summary
- Apply uniform navigation bar styling with inline titles and black headers
- Set toolbar backgrounds to app background color across Input, History, Summary, and Manage views

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4075ea0c08321bcbb0ba76f8858e0