### PR TITLE
Style navigation bar black and manage picker background

### DIFF
--- a/BudgetApp.swift
+++ b/BudgetApp.swift
@@ -12,12 +12,16 @@ struct BudgetApp: App {
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor(Color.appBackground)
+        appearance.backgroundColor = UIColor.black
         appearance.titleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         appearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
         UINavigationBar.appearance().compactAppearance = appearance
+
+        let segmented = UISegmentedControl.appearance()
+        segmented.backgroundColor = UIColor(Color.appBackground)
+        segmented.selectedSegmentTintColor = UIColor(Color.appAccent)
     }
 
     var body: some Scene {

--- a/HistoryView.swift
+++ b/HistoryView.swift
@@ -82,7 +82,7 @@ struct HistoryView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.black, for: .navigationBar)
     }
 
     // MARK: - Helpers

--- a/InputView.swift
+++ b/InputView.swift
@@ -177,7 +177,7 @@ struct InputView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.black, for: .navigationBar)
     }
 
     /// Main form broken out for easier type-checking

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -65,7 +65,7 @@ struct ManageView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.black, for: .navigationBar)
     }
 
     // MARK: - Sections

--- a/SummaryView.swift
+++ b/SummaryView.swift
@@ -91,7 +91,7 @@ struct SummaryView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.black, for: .navigationBar)
     }
 
     // MARK: - Filtering for selected month/year


### PR DESCRIPTION
## Summary
- Set navigation bar appearance to pure black and applied black toolbar backgrounds across main views.
- Styled the Manage tab's segmented control with a gray background matching the app theme.

## Testing
- ⚠️ `swift build` *(missing Package.swift manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68c40ae63c5c8321b87281371a170f08