### PR TITLE
Use dark text for active segmented picker option

### DIFF
--- a/ManageView.swift
+++ b/ManageView.swift
@@ -6,6 +6,17 @@ import UIKit
 struct ManageView: View {
     @Environment(\.modelContext) private var context
 
+    init() {
+        let segmented = UISegmentedControl.appearance()
+        segmented.selectedSegmentTintColor = UIColor(Color.appAccent)
+        segmented.setTitleTextAttributes([
+            .foregroundColor: UIColor(Color.appText)
+        ], for: .normal)
+        segmented.setTitleTextAttributes([
+            .foregroundColor: UIColor(Color.appBackground)
+        ], for: .selected)
+    }
+
     // Order by sortIndex, then name
     @Query(sort: [
         SortDescriptor(\Category.sortIndex, order: .forward),


### PR DESCRIPTION
## Summary
- Ensure segmented picker's active segment text uses dark gray while keeping cyan background

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c40d4e00ec8321b39d867e4fe29cbd