### PR TITLE
style: unify primary buttons

### DIFF
--- a/AppButtonStyle.swift
+++ b/AppButtonStyle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct AppButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        AppButton(configuration: configuration)
+    }
+
+    private struct AppButton: View {
+        @Environment(\.isEnabled) private var isEnabled
+        let configuration: Configuration
+
+        var body: some View {
+            configuration.label
+                .fontWeight(.semibold)
+                .foregroundColor(.appAccent)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(Color.appTabBar)
+                .cornerRadius(8)
+                .opacity(isEnabled ? (configuration.isPressed ? 0.8 : 1.0) : 0.5)
+        }
+    }
+}

--- a/InputView.swift
+++ b/InputView.swift
@@ -297,11 +297,9 @@ struct InputView: View {
     @ViewBuilder private var saveSection: some View {
         Section {
             Button(action: save) {
-                HStack { Spacer(); Text("Save entry").fontWeight(.semibold); Spacer() }
+                Text("Save entry")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(Color.appSecondaryBackground)
-            .foregroundColor(Color.appAccent)
+            .buttonStyle(AppButtonStyle())
             .disabled(!canSave)
         }
     }

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -136,9 +136,7 @@ struct ManageView: View {
                     }
                     .onChange(of: newCategoryIsIncome) { _ in dismissKeyboard() }
                     Button("Add category", action: addCategory)
-                        .buttonStyle(.borderedProminent)
-                        .tint(.gray.opacity(0.3))
-                        .foregroundStyle(Color.appAccent)
+                        .buttonStyle(AppButtonStyle())
                         .disabled(trimmed(newCategory).isEmpty || newCategoryIsIncome == nil)
                 }
                 .transition(.opacity)
@@ -194,10 +192,8 @@ struct ManageView: View {
                         onDone: { },
                         autocapitalization: .words
                     )
-                    Button("Add", action: addPayment)
-                        .buttonStyle(.borderedProminent)
-                        .tint(.gray.opacity(0.3))
-                        .foregroundStyle(Color.appAccent)
+                    Button("Add payment type", action: addPayment)
+                        .buttonStyle(AppButtonStyle())
                         .disabled(trimmed(newPayment).isEmpty)
                 }
                 .transition(.opacity)


### PR DESCRIPTION
## Summary
- create reusable `AppButtonStyle` for light gray background and cyan text
- apply new style to Save Entry, Add Category, and Add Payment Type buttons

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c40f3979348321ad62c0cb5f241136