### PR TITLE
Standardize custom button styling

### DIFF
--- a/AppButtonStyle.swift
+++ b/AppButtonStyle.swift
@@ -14,9 +14,8 @@ struct AppButtonStyle: ButtonStyle {
                 .fontWeight(.semibold)
                 .foregroundColor(.appAccent)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
+                .padding(.vertical, 12)
                 .background(Color.appTabBar)
-                .cornerRadius(8)
                 .opacity(isEnabled ? (configuration.isPressed ? 0.8 : 1.0) : 0.5)
         }
     }

--- a/InputView.swift
+++ b/InputView.swift
@@ -297,10 +297,12 @@ struct InputView: View {
     @ViewBuilder private var saveSection: some View {
         Section {
             Button(action: save) {
-                Text("Save entry")
+                Text("Save Entry")
             }
             .buttonStyle(AppButtonStyle())
             .disabled(!canSave)
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
         }
     }
 

--- a/ManageView.swift
+++ b/ManageView.swift
@@ -135,12 +135,14 @@ struct ManageView: View {
                         }
                     }
                     .onChange(of: newCategoryIsIncome) { _ in dismissKeyboard() }
-                    Button("Add category", action: addCategory)
+                    Button("Add Category", action: addCategory)
                         .buttonStyle(AppButtonStyle())
                         .disabled(trimmed(newCategory).isEmpty || newCategoryIsIncome == nil)
                 }
                 .transition(.opacity)
                 .padding(.top, 8)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
             }
         } header: {
             HStack {
@@ -192,12 +194,14 @@ struct ManageView: View {
                         onDone: { },
                         autocapitalization: .words
                     )
-                    Button("Add payment type", action: addPayment)
+                    Button("Add Payment Type", action: addPayment)
                         .buttonStyle(AppButtonStyle())
                         .disabled(trimmed(newPayment).isEmpty)
                 }
                 .transition(.opacity)
                 .padding(.top, 8)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
             }
         } header: {
             HStack {


### PR DESCRIPTION
## Summary
- Rebuild AppButtonStyle with light gray tab bar background and cyan text
- Apply unified button style to Save Entry, Add Category, and Add Payment Type actions
- Strip form row insets/separators so buttons render without dark outlines

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c414c36e788321947a105229488120