### PR TITLE
Move manage picker below navigation bar

### DIFF
--- a/ManageView.swift
+++ b/ManageView.swift
@@ -40,26 +40,25 @@ struct ManageView: View {
 
     var body: some View {
         NavigationStack {
-            VStack {
-                Picker("", selection: $showingCategories) {
-                    Text("Categories").tag(true)
-                    Text("Payment Types").tag(false)
-                }
-                .pickerStyle(.segmented)
-                .padding()
-
-                Form {
-                    if showingCategories {
-                        categorySection
-                    } else {
-                        paymentSection
+            Form {
+                Section {
+                    Picker("", selection: $showingCategories) {
+                        Text("Categories").tag(true)
+                        Text("Payment Types").tag(false)
                     }
+                    .pickerStyle(.segmented)
                 }
-                .scrollContentBackground(.hidden)
-                .background(Color.appBackground)
-                .listRowBackground(Color.appSecondaryBackground)
-                .scrollDismissesKeyboard(.interactively)
+
+                if showingCategories {
+                    categorySection
+                } else {
+                    paymentSection
+                }
             }
+            .scrollContentBackground(.hidden)
+            .background(Color.appBackground)
+            .listRowBackground(Color.appSecondaryBackground)
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Manage")
             .toolbar { EditButton() }
             .task { normalizeSortIndicesIfNeeded() }


### PR DESCRIPTION
## Summary
- show the Categories/Payment Types toggle inside the main form instead of in the navigation bar

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c47f0415e883218bb8b0451e59f7d8