### PR TITLE
Constrain manage view bottom sheets

### DIFF
--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -86,6 +86,7 @@ struct ManageView: View {
                     onAdd: addCategory,
                     onClose: closeCategorySheet
                 )
+                .frame(maxHeight: UIScreen.main.bounds.height / 2)
                 .transition(.move(edge: .bottom))
             }
 
@@ -96,6 +97,7 @@ struct ManageView: View {
                     onAdd: addPayment,
                     onClose: closePaymentSheet
                 )
+                .frame(maxHeight: UIScreen.main.bounds.height / 2)
                 .transition(.move(edge: .bottom))
             }
         }
@@ -337,7 +339,7 @@ private struct CategoryFormSheet: View {
     var onClose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Spacer()
                 Button(action: onClose) {
@@ -366,6 +368,7 @@ private struct CategoryFormSheet: View {
                         .tag(Bool?.some(isIncome))
                 }
             }
+            .pickerStyle(.segmented)
             .onChange(of: newCategoryIsIncome) { _ in dismissKeyboard() }
             Button("Add Category", action: onAdd)
                 .buttonStyle(AppButtonStyle())
@@ -385,7 +388,7 @@ private struct PaymentFormSheet: View {
     var onClose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Spacer()
                 Button(action: onClose) {


### PR DESCRIPTION
## Summary
- Limit category and payment form sheets to half screen
- Reduce spacing and use segmented picker for compact layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a7e02ec8832197e5b2df3c4bcd55