### PR TITLE
Style manage sheets to match dark theme

### DIFF
--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -85,7 +85,7 @@ struct ManageView: View {
             )
             .presentationDetents([.fraction(0.5)])
             .presentationDragIndicator(.visible)
-            .presentationBackground(Color.appSecondaryBackground)
+            .presentationBackground(Color.black)
         }
         .sheet(isPresented: $showPaymentForm) {
             PaymentFormSheet(
@@ -95,7 +95,7 @@ struct ManageView: View {
             )
             .presentationDetents([.fraction(0.5)])
             .presentationDragIndicator(.visible)
-            .presentationBackground(Color.appSecondaryBackground)
+            .presentationBackground(Color.black)
         }
     }
 
@@ -367,9 +367,11 @@ private struct CategoryFormSheet: View {
             .onChange(of: newCategoryIsIncome) { _ in dismissKeyboard() }
             .formField()
 
-            Button("Add Category", action: onAdd)
-                .buttonStyle(AppButtonStyle())
-                .disabled(newCategory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || newCategoryIsIncome == nil)
+            Button(action: onAdd) {
+                Text("Add Category")
+            }
+            .buttonStyle(AppButtonStyle())
+            .disabled(newCategory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || newCategoryIsIncome == nil)
         }
         .padding()
     }
@@ -399,9 +401,11 @@ private struct PaymentFormSheet: View {
             )
             .formField()
 
-            Button("Add Payment Type", action: onAdd)
-                .buttonStyle(AppButtonStyle())
-                .disabled(newPayment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            Button(action: onAdd) {
+                Text("Add Payment Type")
+            }
+            .buttonStyle(AppButtonStyle())
+            .disabled(newPayment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .padding()
     }
@@ -414,10 +418,6 @@ private extension View {
             .background(
                 RoundedRectangle(cornerRadius: 8)
                     .fill(Color.appBackground)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.appAccent.opacity(0.3))
             )
     }
 }


### PR DESCRIPTION
## Summary
- Make management bottom sheets use black background
- Remove cyan field outlines and match dark grey app background
- Use shared app button styling for sheet actions

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project Budget.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ab247d70832192bee19bdfd15855