### PR TITLE
style: unify input and button appearance

### DIFF
--- a/Budget/AppButtonStyle.swift
+++ b/Budget/AppButtonStyle.swift
@@ -15,7 +15,10 @@ struct AppButtonStyle: ButtonStyle {
                 .foregroundColor(.appAccent)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
-                .background(Color.appTabBar)
+                .background(
+                    Capsule()
+                        .fill(Color.appTabBar)
+                )
                 .opacity(isEnabled ? (configuration.isPressed ? 0.8 : 1.0) : 0.5)
         }
     }

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -236,6 +236,7 @@ struct InputView: View {
                 onCancel: { /* nothing else to do */ },
                 onDone: { /* just collapse; formatting already applied */ }
             )
+            .formField()
         }
     }
 
@@ -247,6 +248,7 @@ struct InputView: View {
                         dismissKeyboard()
                     }
                 }
+                .formField()
         }
     }
 
@@ -262,6 +264,7 @@ struct InputView: View {
                     }
                 }
                 .onChange(of: selectedMethod) { _ in dismissKeyboard() }
+                .formField()
             }
         }
     }
@@ -279,6 +282,7 @@ struct InputView: View {
                     }
                 }
                 .onChange(of: selectedCategory) { _ in dismissKeyboard() }
+                .formField()
             }
         }
     }
@@ -291,6 +295,7 @@ struct InputView: View {
                 onCancel: { /* nothing extra */ },
                 onDone: { /* just collapse */ }
             )
+            .formField()
         }
     }
 

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -411,7 +411,7 @@ private struct PaymentFormSheet: View {
     }
 }
 
-private extension View {
+extension View {
     func formField() -> some View {
         self
             .padding(12)


### PR DESCRIPTION
## Summary
- restyle app button with tab bar-colored capsule and cyan text
- expose formField helper and use it for Input screen fields

## Testing
- `xcodebuild -scheme Budget -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ad35de548321b35dca7d4a761abb