### PR TITLE
Restyle input fields for updated design

### DIFF
--- a/Budget/Color+Theme.swift
+++ b/Budget/Color+Theme.swift
@@ -6,4 +6,5 @@ extension Color {
     static let appAccent = Color(red: 0.0/255.0, green: 255.0/255.0, blue: 255.0/255.0)
     static let appText = Color.white
     static let appTabBar = Color(red: 49.0/255.0, green: 50.0/255.0, blue: 50.0/255.0)
+    static let appPlaceholderText = Color(red: 39.0/255.0, green: 40.0/255.0, blue: 40.0/255.0)
 }

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -41,7 +41,10 @@ struct MoneyTextField: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UITextField {
         let tf = UITextField(frame: .zero)
-        tf.placeholder = placeholder
+        tf.attributedPlaceholder = NSAttributedString(
+            string: placeholder,
+            attributes: [.foregroundColor: UIColor(Color.appPlaceholderText)]
+        )
         tf.keyboardType = .numberPad
         tf.delegate = context.coordinator
         tf.borderStyle = .none
@@ -116,7 +119,10 @@ struct AccessoryTextField: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UITextField {
         let tf: UITextField = prefersEmoji ? EmojiTextField(frame: .zero) : UITextField(frame: .zero)
-        tf.placeholder = placeholder
+        tf.attributedPlaceholder = NSAttributedString(
+            string: placeholder,
+            attributes: [.foregroundColor: UIColor(Color.appPlaceholderText)]
+        )
         tf.delegate = context.coordinator
         tf.borderStyle = .none
         tf.keyboardType = keyboardType

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -414,10 +414,10 @@ private struct PaymentFormSheet: View {
 extension View {
     func formField() -> some View {
         self
-            .padding(12)
+            .padding(8)
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.appBackground)
+                    .fill(Color.appTabBar)
             )
     }
 }


### PR DESCRIPTION
## Summary
- Shrink form field padding and use tab bar grey background
- Ensure text fields use white text with darker grey placeholders
- Add dedicated placeholder color constant

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4afb87d4883218be42e7e6fb3b129