### PR TITLE
Fix button overlay color

### DIFF
--- a/Budget/AppButtonStyle.swift
+++ b/Budget/AppButtonStyle.swift
@@ -6,7 +6,6 @@ struct AppButtonStyle: ButtonStyle {
     }
 
     private struct AppButton: View {
-        @Environment(\.isEnabled) private var isEnabled
         let configuration: Configuration
 
         var body: some View {
@@ -19,7 +18,7 @@ struct AppButtonStyle: ButtonStyle {
                     Capsule()
                         .fill(Color.appTabBar)
                 )
-                .opacity(isEnabled ? (configuration.isPressed ? 0.8 : 1.0) : 0.5)
+                .opacity(configuration.isPressed ? 0.8 : 1.0)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove dark overlay on app buttons so they match tab bar color and keep cyan text

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project Budget.xcodeproj -scheme Budget -sdk iphonesimulator build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b39d72b0832189d68e20d4448834