### PR TITLE
Refine chip layouts and add date picker

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -169,9 +169,6 @@ struct InputView: View {
     @State private var alertMessage: String?
 
     private let chipHeight: CGFloat = 40
-    private var chipRows: [GridItem] {
-        Array(repeating: GridItem(.fixed(chipHeight), spacing: 8), count: 2)
-    }
 
     var body: some View {
         NavigationStack {
@@ -198,6 +195,8 @@ struct InputView: View {
                 paymentSection
                 fieldTitle("Category")
                 categorySection
+                fieldTitle("Date")
+                dateSection
                 saveSection
             }
             .padding()
@@ -260,7 +259,7 @@ struct InputView: View {
             Button("Add default payment types") { seedDefaults(paymentsOnly: true) }
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
-                LazyHGrid(rows: chipRows, spacing: 8) {
+                HStack(spacing: 8) {
                     ForEach(methods) { pm in
                         Text(pm.name)
                             .padding(.horizontal, 16)
@@ -275,7 +274,7 @@ struct InputView: View {
                     }
                 }
             }
-            .frame(height: chipHeight * 2 + 8)
+            .frame(height: chipHeight)
         }
     }
 
@@ -283,24 +282,26 @@ struct InputView: View {
         if categories.isEmpty {
             Button("Add default categories") { seedDefaults(categoriesOnly: true) }
         } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHGrid(rows: chipRows, spacing: 8) {
-                    ForEach(categories) { cat in
-                        Text("\(cat.emoji ?? "") \(cat.name)")
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 10)
-                            .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
-                            .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
-                            .clipShape(Capsule())
-                            .onTapGesture {
-                                selectedCategory = cat
-                                dismissKeyboard()
-                            }
+            WrappingHStack(categories, spacing: 8, lineSpacing: 8) { cat in
+                Text("\(cat.emoji ?? "") \(cat.name)")
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
+                    .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
+                    .clipShape(Capsule())
+                    .onTapGesture {
+                        selectedCategory = cat
+                        dismissKeyboard()
                     }
-                }
             }
-            .frame(height: chipHeight * 2 + 8)
         }
+    }
+
+    @ViewBuilder private var dateSection: some View {
+        DatePicker("", selection: $date, displayedComponents: .date)
+            .labelsHidden()
+            .datePickerStyle(.compact)
+            .formField()
     }
 
     @ViewBuilder private var descriptionSection: some View {

--- a/Budget/WrappingHStack.swift
+++ b/Budget/WrappingHStack.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct WrappingHStack<Data: RandomAccessCollection, Content: View>: View where Data.Element: Identifiable {
+    let data: Data
+    let spacing: CGFloat
+    let lineSpacing: CGFloat
+    let content: (Data.Element) -> Content
+    @State private var totalHeight: CGFloat = .zero
+
+    init(_ data: Data, spacing: CGFloat = 8, lineSpacing: CGFloat = 8, @ViewBuilder content: @escaping (Data.Element) -> Content) {
+        self.data = data
+        self.spacing = spacing
+        self.lineSpacing = lineSpacing
+        self.content = content
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            self.generateContent(in: geometry)
+        }
+        .frame(height: totalHeight)
+    }
+
+    private func generateContent(in geometry: GeometryProxy) -> some View {
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+
+        return ZStack(alignment: .topLeading) {
+            ForEach(data) { item in
+                content(item)
+                    .alignmentGuide(.leading) { d in
+                        if width + d.width > geometry.size.width {
+                            width = 0
+                            height += d.height + lineSpacing
+                        }
+                        let result = width
+                        width += d.width + spacing
+                        return result
+                    }
+                    .alignmentGuide(.top) { _ in
+                        let result = height
+                        return result
+                    }
+            }
+        }
+        .background(GeometryReader { geo in
+            Color.clear
+                .preference(key: HeightPreferenceKey.self, value: geo.size.height)
+        })
+        .onPreferenceChange(HeightPreferenceKey.self) { totalHeight = $0 }
+    }
+}
+
+private struct HeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+


### PR DESCRIPTION
## Summary
- Keep payment type chips in a single scrollable row
- Wrap category chips left-to-right using a custom `WrappingHStack`
- Add a date picker field below categories styled like other inputs

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme Budget` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c2496ed083219ce0c714c0f09cf7