### PR TITLE
Improve chip layout by introducing custom wrapping stack

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -282,17 +282,19 @@ struct InputView: View {
         if categories.isEmpty {
             Button("Add default categories") { seedDefaults(categoriesOnly: true) }
         } else {
-            WrappingHStack(categories, spacing: 8, lineSpacing: 8) { cat in
-                Text("\(cat.emoji ?? "") \(cat.name)")
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
-                    .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
-                    .clipShape(Capsule())
-                    .onTapGesture {
-                        selectedCategory = cat
-                        dismissKeyboard()
-                    }
+            WrappingHStack(spacing: 8, lineSpacing: 8) {
+                ForEach(categories) { cat in
+                    Text("\(cat.emoji ?? "") \(cat.name)")
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
+                        .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
+                        .clipShape(Capsule())
+                        .onTapGesture {
+                            selectedCategory = cat
+                            dismissKeyboard()
+                        }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace old state-based chip layout with a dedicated `Layout` implementation
- Use the new wrapping stack in `InputView` so category chips flow correctly

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c3f93a80832186158c3cdfe95a87