### PR TITLE
Display category chips in two horizontal rows

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -282,20 +282,27 @@ struct InputView: View {
         if categories.isEmpty {
             Button("Add default categories") { seedDefaults(categoriesOnly: true) }
         } else {
-            WrappingHStack(spacing: 8, lineSpacing: 8) {
-                ForEach(categories) { cat in
-                    Text("\(cat.emoji ?? "") \(cat.name)")
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
-                        .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
-                        .clipShape(Capsule())
-                        .onTapGesture {
-                            selectedCategory = cat
-                            dismissKeyboard()
-                        }
+            let rows: [GridItem] = [
+                GridItem(.fixed(chipHeight), spacing: 8),
+                GridItem(.fixed(chipHeight))
+            ]
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHGrid(rows: rows, spacing: 8) {
+                    ForEach(categories) { cat in
+                        Text("\(cat.emoji ?? "") \(cat.name)")
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
+                            .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
+                            .clipShape(Capsule())
+                            .onTapGesture {
+                                selectedCategory = cat
+                                dismissKeyboard()
+                            }
+                    }
                 }
             }
+            .frame(height: chipHeight * 2 + 8)
         }
     }
 


### PR DESCRIPTION
## Summary
- arrange category chips in two horizontally scrolling rows

## Testing
- `xcodebuild -project Budget.xcodeproj -scheme Budget -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c60514d883219cac800fc98eda8b