### PR TITLE
Fix category chip layout and manage screen add button

### DIFF
--- a/Budget/AppButtonStyle.swift
+++ b/Budget/AppButtonStyle.swift
@@ -6,19 +6,20 @@ struct AppButtonStyle: ButtonStyle {
     }
 
     private struct AppButton: View {
+        @Environment(\.isEnabled) private var isEnabled
         let configuration: Configuration
 
         var body: some View {
             configuration.label
                 .fontWeight(.semibold)
-                .foregroundColor(.appAccent)
+                .foregroundColor(isEnabled ? .appAccent : .gray)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
                 .background(
                     Capsule()
                         .fill(Color.appTabBar)
                 )
-                .opacity(configuration.isPressed ? 0.8 : 1.0)
+                .opacity(isEnabled ? (configuration.isPressed ? 0.8 : 1.0) : 0.5)
         }
     }
 }

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -282,24 +282,12 @@ struct InputView: View {
         if categories.isEmpty {
             Button("Add default categories") { seedDefaults(categoriesOnly: true) }
         } else {
-            let topRow = stride(from: 0, to: categories.count, by: 2).map { categories[$0] }
-            let bottomRow = stride(from: 1, to: categories.count, by: 2).map { categories[$0] }
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: 8) {
-                        ForEach(topRow) { cat in
-                            categoryChip(for: cat)
-                        }
-                    }
-                    HStack(spacing: 8) {
-                        ForEach(bottomRow) { cat in
-                            categoryChip(for: cat)
-                        }
-                    }
+            WrappingHStack(spacing: 8, lineSpacing: 8) {
+                ForEach(categories) { cat in
+                    categoryChip(for: cat)
                 }
             }
-            .frame(height: chipHeight * 2 + 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -214,15 +214,17 @@ struct ManageView: View {
                 try context.save()
             }
 
-            SHEETS.postCategory(
-                remoteID: newCat.remoteID,
-                name: newCat.name,
-                emoji: newCat.emoji,
-                sortIndex: newCat.sortIndex,
-                isIncome: newCat.isIncome
-            )
-
             closeCategorySheet()
+
+            Task {
+                SHEETS.postCategory(
+                    remoteID: newCat.remoteID,
+                    name: newCat.name,
+                    emoji: newCat.emoji,
+                    sortIndex: newCat.sortIndex,
+                    isIncome: newCat.isIncome
+                )
+            }
         } catch {
             alertMessage = "Could not save category: \(error.localizedDescription)"
             print("SAVE ERROR (Category):", error)


### PR DESCRIPTION
## Summary
- use `WrappingHStack` for category chips to prevent clipping
- ensure category sheet closes before network sync
- show disabled state for app buttons so add button feedback is clear

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c929a0ac8321bd2c72a96333da7a