### PR TITLE
Fix chip scroll padding to allow edge-to-edge layout

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -273,7 +273,9 @@ struct InputView: View {
                             }
                     }
                 }
+                .padding(.horizontal)
             }
+            .padding(.horizontal, -16)
             .frame(height: chipHeight)
         }
     }
@@ -288,7 +290,9 @@ struct InputView: View {
                         categoryChip(for: cat)
                     }
                 }
+                .padding(.horizontal)
             }
+            .padding(.horizontal, -16)
             .frame(height: chipHeight)
         }
     }


### PR DESCRIPTION
## Summary
- let horizontal chip lists extend to screen edges
- maintain outer padding only as scroll boundary

## Testing
- ⚠️ `swift test` (package manifest missing)
- ⚠️ `xcodebuild test` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68c4ccd586e483218dbf411902cba06a