### PR TITLE
Arrange category chips in two scrollable rows

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -285,15 +285,20 @@ struct InputView: View {
             Button("Add default categories") { seedDefaults(categoriesOnly: true) }
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(categories) { cat in
-                        categoryChip(for: cat)
+                HStack(alignment: .top, spacing: 8) {
+                    ForEach(Array(stride(from: 0, to: categories.count, by: 2)), id: \.self) { idx in
+                        VStack(spacing: 8) {
+                            categoryChip(for: categories[idx])
+                            if idx + 1 < categories.count {
+                                categoryChip(for: categories[idx + 1])
+                            }
+                        }
                     }
                 }
                 .padding(.horizontal)
             }
             .padding(.horizontal, -16)
-            .frame(height: chipHeight)
+            .frame(height: chipHeight * 2 + 8)
         }
     }
 


### PR DESCRIPTION
## Summary
- Display category chips in two rows, alternating items between top and bottom rows
- Adjust height to fit both rows and keep horizontal scrolling

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ce76fbf48321a2b2fb51fd4eb703