### PR TITLE
feat: add liquid glass tab bar

### DIFF
--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -49,7 +49,7 @@ struct HomeTabView: View {
                         .padding(.vertical, 8)
                         .frame(width: 80, height: 48)
                         .background(
-                            Capsule().fill(selection == tab ? Color.appAccent : Color.clear)
+                            Capsule().fill(selection == tab ? .thinMaterial : .clear)
                         )
                         .frame(maxWidth: .infinity)
                     }
@@ -60,7 +60,7 @@ struct HomeTabView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(
-                Capsule().fill(Color.appTabBar)
+                Capsule().fill(.ultraThinMaterial)
             )
             .padding(.horizontal, 16)
             .padding(.bottom, 16)


### PR DESCRIPTION
## Summary
- adopt ultra-thin material for tab bar to emulate Apple's liquid glass look
- replace cyan highlight with thin-material selection capsule

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d0b757d48321a8df63a3e3bd34e1