### PR TITLE
Refactor HomeTabView body to ease type-checking

### DIFF
--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -21,49 +21,56 @@ struct HomeTabView: View {
 
     @State private var selection: Tab = .input
 
+    private var contentView: some View {
+        Group {
+            switch selection {
+            case .input: InputView()
+            case .history: HistoryView()
+            case .summary: SummaryView()
+            case .manage: ManageView()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.appBackground)
+    }
+
+    private var tabBar: some View {
+        HStack(spacing: 0) {
+            ForEach(Tab.allCases, id: \.self) { tab in
+                Button {
+                    selection = tab
+                } label: {
+                    VStack(spacing: 4) {
+                        Image(systemName: tab.systemImage)
+                            .font(.system(size: 16, weight: .semibold))
+                        Text(tab.title)
+                            .font(.caption2.bold())
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(width: 80, height: 48)
+                    .background(
+                        Capsule().fill(selection == tab ? .thinMaterial : .clear)
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .frame(maxWidth: .infinity)
+                .foregroundColor(selection == tab ? Color.appBackground : Color.appText)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            Capsule().fill(.ultraThinMaterial)
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 16)
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
-            Group {
-                switch selection {
-                case .input: InputView()
-                case .history: HistoryView()
-                case .summary: SummaryView()
-                case .manage: ManageView()
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.appBackground)
-
-            HStack(spacing: 0) {
-                ForEach(Tab.allCases, id: \.self) { tab in
-                    Button {
-                        selection = tab
-                    } label: {
-                        VStack(spacing: 4) {
-                            Image(systemName: tab.systemImage)
-                                .font(.system(size: 16, weight: .semibold))
-                            Text(tab.title)
-                                .font(.caption2.bold())
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .frame(width: 80, height: 48)
-                        .background(
-                            Capsule().fill(selection == tab ? .thinMaterial : .clear)
-                        )
-                        .frame(maxWidth: .infinity)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .foregroundColor(selection == tab ? Color.appBackground : Color.appText)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(
-                Capsule().fill(.ultraThinMaterial)
-            )
-            .padding(.horizontal, 16)
-            .padding(.bottom, 16)
+            contentView
+            tabBar
         }
         .ignoresSafeArea(.all, edges: .bottom)
     }


### PR DESCRIPTION
## Summary
- Split HomeTabView body into smaller content and tab bar helpers to simplify type checking

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d26e03fc832194922a4f8ca15dba