### PR TITLE
Fix material fill in HomeTabView tab button

### DIFF
--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -65,7 +65,7 @@ struct HomeTabView: View {
             .padding(.vertical, 8)
             .frame(width: 80, height: 48)
             .background(
-                Capsule().fill(isSelected ? .thinMaterial : .clear)
+                Capsule().fill(.thinMaterial).opacity(isSelected ? 1 : 0)
             )
             .frame(maxWidth: .infinity)
         }


### PR DESCRIPTION
## Summary
- Prevent type mismatch by always using `.thinMaterial` for tab background
- Hide unselected tab backgrounds via opacity instead of `.clear`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d524c3a88321881902f01b5507bb