### PR TITLE
Fix background image scaling to fill screen

### DIFF
--- a/Budget/BackgroundView.swift
+++ b/Budget/BackgroundView.swift
@@ -9,6 +9,8 @@ struct BackgroundView: View {
             Image(uiImage: uiImage)
                 .resizable()
                 .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
                 .ignoresSafeArea()
         } else {
             Color.appBackground.ignoresSafeArea()


### PR DESCRIPTION
## Summary
- Ensure background image fills entire screen without squashing

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4de44ebcc8321a14815a6034fbefb