### PR TITLE
Disable hit testing on background image

### DIFF
--- a/Budget/BackgroundView.swift
+++ b/Budget/BackgroundView.swift
@@ -12,8 +12,13 @@ struct BackgroundView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .clipped()
                 .ignoresSafeArea()
+                // Ensure the background image does not intercept touches
+                .allowsHitTesting(false)
         } else {
-            Color.appBackground.ignoresSafeArea()
+            // Static background color that never captures interactions
+            Color.appBackground
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure custom background image is inert by disabling hit testing
- do the same for default background color

## Testing
- `xcodebuild -scheme Budget -project Budget.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e10a0f708321bda6ae96231c1e9a