### PR TITLE
Refactor background image handling

### DIFF
--- a/Budget/BackgroundManager.swift
+++ b/Budget/BackgroundManager.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import UIKit
+
+/// Manages the optional background image for the app.
+class BackgroundManager: ObservableObject {
+    @AppStorage("backgroundImageData") private var storedData: Data?
+    @Published var image: UIImage?
+
+    init() {
+        if let data = storedData, let uiImage = UIImage(data: data) {
+            image = uiImage
+        }
+    }
+
+    /// Update the background image with raw data.
+    func setImageData(_ data: Data) {
+        storedData = data
+        image = UIImage(data: data)
+    }
+}

--- a/Budget/BackgroundView.swift
+++ b/Budget/BackgroundView.swift
@@ -1,24 +1,23 @@
 import SwiftUI
 import UIKit
 
+/// Renders the stored background image behind all content.
 struct BackgroundView: View {
-    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
+    @EnvironmentObject private var manager: BackgroundManager
 
     var body: some View {
-        if let data = backgroundImageData, let uiImage = UIImage(data: data) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .scaledToFill()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .clipped()
-                .ignoresSafeArea()
-                // Ensure the background image does not intercept touches
-                .allowsHitTesting(false)
-        } else {
-            // Static background color that never captures interactions
-            Color.appBackground
-                .ignoresSafeArea()
-                .allowsHitTesting(false)
+        Group {
+            if let image = manager.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
+            } else {
+                Color.appBackground
+            }
         }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
     }
 }

--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -9,6 +9,7 @@ let SHEETS = SheetsClient(
 
 @main
 struct BudgetApp: App {
+    @StateObject private var backgroundManager = BackgroundManager()
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -26,9 +27,13 @@ struct BudgetApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootSwitcherView()
-                .preferredColorScheme(.dark)
-                .tint(.appAccent)
+            ZStack {
+                BackgroundView()
+                RootSwitcherView()
+            }
+            .preferredColorScheme(.dark)
+            .tint(.appAccent)
+            .environmentObject(backgroundManager)
         }
         .modelContainer(for: [Transaction.self, Category.self, PaymentMethod.self])
     }

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -6,7 +6,7 @@ import PhotosUI
 @MainActor
 struct ManageView: View {
     @Environment(\.modelContext) private var context
-    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
+    @EnvironmentObject private var backgroundManager: BackgroundManager
     @State private var backgroundItem: PhotosPickerItem?
 
     init() {
@@ -111,7 +111,7 @@ struct ManageView: View {
             if let newItem {
                 Task {
                     if let data = try? await newItem.loadTransferable(type: Data.self) {
-                        backgroundImageData = data
+                        backgroundManager.setImageData(data)
                     }
                 }
             }

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -5,13 +5,10 @@ struct RootSwitcherView: View {
 
     var body: some View {
         ZStack {
-            BackgroundView()
-            Group {
-                if showSplash {
-                    SplashView()
-                } else {
-                    HomeTabView()
-                }
+            if showSplash {
+                SplashView()
+            } else {
+                HomeTabView()
             }
         }
         .animation(.easeInOut(duration: 0.3), value: showSplash)


### PR DESCRIPTION
## Summary
- Add BackgroundManager to store and publish the selected background image
- Render background image globally via BackgroundView and BudgetApp
- Let ManageView update background using PhotosPicker and clean up old handling

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e26258b48321b2703719c512a198