### PR TITLE
Use picked image as non-intrusive background

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -176,24 +176,24 @@ struct InputView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                if let backgroundImage {
-                    backgroundImage
-                        .resizable()
-                        .scaledToFill()
-                        .ignoresSafeArea()
-                } else {
-                    Color.black.ignoresSafeArea()
-                }
-                formContent
-            }
-            .navigationTitle("Input")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    PhotosPicker(selection: $selectedItem, matching: .images) {
-                        Image(systemName: "plus")
+            formContent
+                .navigationTitle("Input")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        PhotosPicker(selection: $selectedItem, matching: .images) {
+                            Image(systemName: "plus")
+                        }
                     }
                 }
+        }
+        .background {
+            if let backgroundImage {
+                backgroundImage
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
+            } else {
+                Color.black.ignoresSafeArea()
             }
         }
         .onChange(of: selectedItem) { newItem in


### PR DESCRIPTION
## Summary
- Apply user-selected image as a view background instead of layering it in a ZStack so layout no longer stretches to the image size

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4eb42ea108321acef60e2fea75271