### PR TITLE
feat: persist selected background image

### DIFF
--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -9,6 +9,8 @@ let SHEETS = SheetsClient(
 
 @main
 struct BudgetApp: App {
+    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
+
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -26,10 +28,21 @@ struct BudgetApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootSwitcherView()
-                .background(Color.black.ignoresSafeArea())
-                .preferredColorScheme(.dark)
-                .tint(.appAccent)
+            ZStack {
+                if let data = backgroundImageData,
+                   let uiImage = UIImage(data: data) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .ignoresSafeArea()
+                } else {
+                    Color.black.ignoresSafeArea()
+                }
+
+                RootSwitcherView()
+            }
+            .preferredColorScheme(.dark)
+            .tint(.appAccent)
         }
         .modelContainer(for: [Transaction.self, Category.self, PaymentMethod.self])
     }

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -170,7 +170,7 @@ struct InputView: View {
     @State private var alertMessage: String?
 
     @State private var selectedItem: PhotosPickerItem?
-    @State private var backgroundImage: Image?
+    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
 
     private let chipHeight: CGFloat = 40
 
@@ -186,22 +186,12 @@ struct InputView: View {
                     }
                 }
         }
-        .background {
-            if let backgroundImage {
-                backgroundImage
-                    .resizable()
-                    .scaledToFill()
-                    .ignoresSafeArea()
-            } else {
-                Color.black.ignoresSafeArea()
-            }
-        }
+        .background(Color.clear)
         .onChange(of: selectedItem) { newItem in
             if let newItem {
                 Task {
-                    if let data = try? await newItem.loadTransferable(type: Data.self),
-                       let uiImage = UIImage(data: data) {
-                        backgroundImage = Image(uiImage: uiImage)
+                    if let data = try? await newItem.loadTransferable(type: Data.self) {
+                        backgroundImageData = data
                     }
                 }
             }

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -23,7 +23,6 @@ struct RootSwitcherView: View {
 struct SplashView: View {
     var body: some View {
         ZStack {
-            Color.appBackground.ignoresSafeArea()
             VStack(spacing: 12) {
                 Image(systemName: "creditcard.fill")
                     .font(.system(size: 56, weight: .bold))
@@ -33,5 +32,6 @@ struct SplashView: View {
             }
             .foregroundColor(.appText)
         }
+        .ignoresSafeArea()
     }
 }


### PR DESCRIPTION
## Summary
- store chosen background image in user defaults
- render stored image behind all views
- allow splash view to inherit global background

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project Budget.xcodeproj -scheme Budget -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ec3ac6088321b7a757a9d76c0179