### PR TITLE
Ensure consistent black background across app

### DIFF
--- a/Budget/AppButtonStyle.swift
+++ b/Budget/AppButtonStyle.swift
@@ -17,7 +17,7 @@ struct AppButtonStyle: ButtonStyle {
                 .padding(.vertical, 12)
                 .background(
                     Capsule()
-                        .fill(Color.appTabBar)
+                        .fill(Color.appBackground)
                 )
                 .opacity(isEnabled ? (configuration.isPressed ? 0.8 : 1.0) : 0.5)
         }

--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -9,12 +9,10 @@ let SHEETS = SheetsClient(
 
 @main
 struct BudgetApp: App {
-    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
-
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor.black
+        appearance.backgroundColor = UIColor(Color.appBackground)
         appearance.titleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         appearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         UINavigationBar.appearance().standardAppearance = appearance
@@ -29,16 +27,7 @@ struct BudgetApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                if let data = backgroundImageData,
-                   let uiImage = UIImage(data: data) {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .scaledToFill()
-                        .ignoresSafeArea()
-                } else {
-                    Color.black.ignoresSafeArea()
-                }
-
+                Color.appBackground.ignoresSafeArea()
                 RootSwitcherView()
             }
             .preferredColorScheme(.dark)

--- a/Budget/Color+Theme.swift
+++ b/Budget/Color+Theme.swift
@@ -2,8 +2,6 @@ import SwiftUI
 
 extension Color {
     static let appBackground = Color.black
-    static let appSecondaryBackground = Color(red: 27.0/255.0, green: 28.0/255.0, blue: 28.0/255.0)
     static let appAccent = Color(red: 0.0/255.0, green: 255.0/255.0, blue: 255.0/255.0)
     static let appText = Color.white
-    static let appTabBar = Color(red: 49.0/255.0, green: 50.0/255.0, blue: 50.0/255.0)
 }

--- a/Budget/HistoryView.swift
+++ b/Budget/HistoryView.swift
@@ -73,16 +73,16 @@ struct HistoryView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(Color.clear)
-            .listRowBackground(Color.appSecondaryBackground)
+            .background(Color.appBackground)
+            .listRowBackground(Color.appBackground)
             .navigationTitle("History")
             .toolbar { EditButton() } // enables swipe-to-delete / Edit
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Helpers

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -20,7 +20,6 @@ struct HomeTabView: View {
     }
 
     @State private var selection: Tab = .input
-    @Namespace private var animation
 
     private var contentView: some View {
         Group {
@@ -32,7 +31,7 @@ struct HomeTabView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.clear)
+        .background(Color.appBackground)
     }
 
     private var tabBar: some View {
@@ -43,24 +42,7 @@ struct HomeTabView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(
-            Capsule()
-                .fill(.ultraThinMaterial)
-                .background(
-                    Capsule()
-                        .fill(Color.white.opacity(0.05))
-                )
-                .overlay(
-                    Capsule()
-                        .stroke(
-                            LinearGradient(colors: [Color.white.opacity(0.8), Color.white.opacity(0.1)],
-                                           startPoint: .topLeading,
-                                           endPoint: .bottomTrailing),
-                            lineWidth: 1
-                        )
-                )
-                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 5)
-        )
+        .background(Color.appBackground)
         .padding(.horizontal, 16)
         .padding(.bottom, 16)
     }
@@ -79,26 +61,10 @@ struct HomeTabView: View {
                 Text(tab.title)
                     .font(.caption2.bold())
             }
-            .foregroundColor(isSelected ? .black : .gray)
+            .foregroundColor(isSelected ? .appAccent : .appText)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .frame(width: 80, height: 48)
-            .background(
-                ZStack {
-                    if isSelected {
-                        Capsule()
-                            .fill(.ultraThinMaterial)
-                            .overlay(
-                                Capsule()
-                                    .stroke(Color.white.opacity(0.6), lineWidth: 1)
-                                    .blendMode(.overlay)
-                            )
-                            .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
-                            .matchedGeometryEffect(id: "TAB", in: animation)
-                    }
-                }
-            )
-            .frame(maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)
     }
@@ -108,6 +74,7 @@ struct HomeTabView: View {
             contentView
             tabBar
         }
+        .background(Color.appBackground)
         .ignoresSafeArea(.all, edges: .bottom)
     }
 }

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import SwiftData
 import UIKit
-import PhotosUI
 
 // MARK: - UIKit-powered money field with a guaranteed inputAccessoryView
 struct MoneyTextField: UIViewRepresentable {
@@ -58,7 +57,7 @@ struct MoneyTextField: UIViewRepresentable {
         let flex = UIBarButtonItem(systemItem: .flexibleSpace)
         let done = UIBarButtonItem(title: "Done", style: .done, target: context.coordinator, action: #selector(Coordinator.tapDone(_:)))
         bar.items = [cancel, flex, done]
-        bar.barTintColor = UIColor(Color.appSecondaryBackground)
+        bar.barTintColor = UIColor(Color.appBackground)
         bar.tintColor = UIColor(Color.appAccent)
         tf.inputAccessoryView = bar
 
@@ -133,7 +132,7 @@ struct AccessoryTextField: UIViewRepresentable {
         let flex = UIBarButtonItem(systemItem: .flexibleSpace)
         let done = UIBarButtonItem(title: "Done", style: .done, target: context.coordinator, action: #selector(Coordinator.tapDone(_:)))
         bar.items = [cancel, flex, done]
-        bar.barTintColor = UIColor(Color.appSecondaryBackground)
+        bar.barTintColor = UIColor(Color.appBackground)
         bar.tintColor = UIColor(Color.appAccent)
         tf.inputAccessoryView = bar
 
@@ -169,8 +168,6 @@ struct InputView: View {
     @State private var showSavedToast = false
     @State private var alertMessage: String?
 
-    @State private var selectedItem: PhotosPickerItem?
-    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
 
     private let chipHeight: CGFloat = 40
 
@@ -178,28 +175,12 @@ struct InputView: View {
         NavigationStack {
             formContent
                 .navigationTitle("Input")
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        PhotosPicker(selection: $selectedItem, matching: .images) {
-                            Image(systemName: "plus")
-                        }
-                    }
-                }
         }
-        .background(Color.clear)
-        .onChange(of: selectedItem) { newItem in
-            if let newItem {
-                Task {
-                    if let data = try? await newItem.loadTransferable(type: Data.self) {
-                        backgroundImageData = data
-                    }
-                }
-            }
-        }
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     /// Main form broken out for easier type-checking
@@ -221,7 +202,7 @@ struct InputView: View {
             }
             .padding()
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .scrollDismissesKeyboard(.interactively)
         .task {
             if categories.isEmpty || methods.isEmpty { seedDefaults() }
@@ -240,7 +221,7 @@ struct InputView: View {
             Text("Saved ✔︎")
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
-                .background(Color.appSecondaryBackground.opacity(0.8))
+                .background(Color.appBackground.opacity(0.8))
                 .foregroundStyle(Color.appText)
                 .cornerRadius(8)
                 .padding(.top)
@@ -281,16 +262,16 @@ struct InputView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(methods) { pm in
-                        Text(pm.name)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 10)
-                            .background(selectedMethod == pm ? Color.appAccent : Color.appTabBar)
-                            .foregroundColor(selectedMethod == pm ? Color.appBackground : Color.appText)
-                            .clipShape(Capsule())
-                            .onTapGesture {
-                                selectedMethod = pm
-                                dismissKeyboard()
-                            }
+                            Text(pm.name)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 10)
+                                .background(selectedMethod == pm ? Color.appAccent : Color.appBackground)
+                                .foregroundColor(selectedMethod == pm ? Color.appBackground : Color.appText)
+                                .clipShape(Capsule())
+                                .onTapGesture {
+                                    selectedMethod = pm
+                                    dismissKeyboard()
+                                }
                     }
                 }
                 .padding(.horizontal)
@@ -326,7 +307,7 @@ struct InputView: View {
         Text("\(cat.emoji ?? "") \(cat.name)")
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
-            .background(selectedCategory == cat ? Color.appAccent : Color.appTabBar)
+            .background(selectedCategory == cat ? Color.appAccent : Color.appBackground)
             .foregroundColor(selectedCategory == cat ? Color.appBackground : Color.appText)
             .clipShape(Capsule())
             .onTapGesture {

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -55,8 +55,8 @@ struct ManageView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(Color.clear)
-            .listRowBackground(Color.appSecondaryBackground)
+            .background(Color.appBackground)
+            .listRowBackground(Color.appBackground)
             .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Manage")
             .toolbar {
@@ -74,11 +74,11 @@ struct ManageView: View {
                 Text(alertMessage ?? "")
             }
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
         .sheet(isPresented: $showCategoryForm) {
             CategoryFormSheet(
                 newCategory: $newCategory,
@@ -89,7 +89,7 @@ struct ManageView: View {
             )
             .presentationDetents([.fraction(0.5)])
             .presentationDragIndicator(.visible)
-            .presentationBackground(Color.black)
+            .presentationBackground(Color.appBackground)
         }
         .sheet(isPresented: $showPaymentForm) {
             PaymentFormSheet(
@@ -99,7 +99,7 @@ struct ManageView: View {
             )
             .presentationDetents([.fraction(0.5)])
             .presentationDragIndicator(.visible)
-            .presentationBackground(Color.black)
+            .presentationBackground(Color.appBackground)
         }
     }
 
@@ -418,7 +418,7 @@ extension View {
             .padding(12)
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.appTabBar)
+                    .fill(Color.appBackground)
             )
     }
 }

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -11,6 +11,7 @@ struct RootSwitcherView: View {
                 HomeTabView()
             }
         }
+        .background(Color.appBackground)
         .animation(.easeInOut(duration: 0.3), value: showSplash)
         .task {
             // Simulate small load, then switch to Home
@@ -32,6 +33,7 @@ struct SplashView: View {
             }
             .foregroundColor(.appText)
         }
+        .background(Color.appBackground)
         .ignoresSafeArea()
     }
 }

--- a/Budget/SummaryView.swift
+++ b/Budget/SummaryView.swift
@@ -83,15 +83,15 @@ struct SummaryView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(Color.clear)
-            .listRowBackground(Color.appSecondaryBackground)
+            .background(Color.appBackground)
+            .listRowBackground(Color.appBackground)
             .navigationTitle("Summary")
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Filtering for selected month/year


### PR DESCRIPTION
## Summary
- remove background image customization and enforce black app background
- replace secondary and tab colors with unified black background
- simplify tab bar and view layouts for a seamless dark appearance

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ed7df4948321ae527377dc3a4582