### PR TITLE
Use theme background and drop image backdrop

### DIFF
--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -9,12 +9,10 @@ let SHEETS = SheetsClient(
 
 @main
 struct BudgetApp: App {
-    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
-
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor.black
+        appearance.backgroundColor = UIColor(Color.appBackground)
         appearance.titleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         appearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         UINavigationBar.appearance().standardAppearance = appearance
@@ -29,16 +27,7 @@ struct BudgetApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                if let data = backgroundImageData,
-                   let uiImage = UIImage(data: data) {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .scaledToFill()
-                        .ignoresSafeArea()
-                } else {
-                    Color.black.ignoresSafeArea()
-                }
-
+                Color.appBackground.ignoresSafeArea()
                 RootSwitcherView()
             }
             .preferredColorScheme(.dark)

--- a/Budget/HistoryView.swift
+++ b/Budget/HistoryView.swift
@@ -73,16 +73,16 @@ struct HistoryView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(Color.clear)
+            .background(Color.appBackground)
             .listRowBackground(Color.appSecondaryBackground)
             .navigationTitle("History")
             .toolbar { EditButton() } // enables swipe-to-delete / Edit
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Helpers

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -32,7 +32,7 @@ struct HomeTabView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.clear)
+        .background(Color.appBackground)
     }
 
     private var tabBar: some View {

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import SwiftData
 import UIKit
-import PhotosUI
 
 // MARK: - UIKit-powered money field with a guaranteed inputAccessoryView
 struct MoneyTextField: UIViewRepresentable {
@@ -169,37 +168,18 @@ struct InputView: View {
     @State private var showSavedToast = false
     @State private var alertMessage: String?
 
-    @State private var selectedItem: PhotosPickerItem?
-    @AppStorage("backgroundImageData") private var backgroundImageData: Data?
-
     private let chipHeight: CGFloat = 40
 
     var body: some View {
         NavigationStack {
             formContent
                 .navigationTitle("Input")
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        PhotosPicker(selection: $selectedItem, matching: .images) {
-                            Image(systemName: "plus")
-                        }
-                    }
-                }
         }
-        .background(Color.clear)
-        .onChange(of: selectedItem) { newItem in
-            if let newItem {
-                Task {
-                    if let data = try? await newItem.loadTransferable(type: Data.self) {
-                        backgroundImageData = data
-                    }
-                }
-            }
-        }
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     /// Main form broken out for easier type-checking
@@ -221,7 +201,7 @@ struct InputView: View {
             }
             .padding()
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .scrollDismissesKeyboard(.interactively)
         .task {
             if categories.isEmpty || methods.isEmpty { seedDefaults() }

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -55,7 +55,7 @@ struct ManageView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(Color.clear)
+            .background(Color.appBackground)
             .listRowBackground(Color.appSecondaryBackground)
             .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Manage")
@@ -74,11 +74,11 @@ struct ManageView: View {
                 Text(alertMessage ?? "")
             }
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
         .sheet(isPresented: $showCategoryForm) {
             CategoryFormSheet(
                 newCategory: $newCategory,
@@ -89,7 +89,7 @@ struct ManageView: View {
             )
             .presentationDetents([.fraction(0.5)])
             .presentationDragIndicator(.visible)
-            .presentationBackground(Color.black)
+            .presentationBackground(Color.appBackground)
         }
         .sheet(isPresented: $showPaymentForm) {
             PaymentFormSheet(
@@ -99,7 +99,7 @@ struct ManageView: View {
             )
             .presentationDetents([.fraction(0.5)])
             .presentationDragIndicator(.visible)
-            .presentationBackground(Color.black)
+            .presentationBackground(Color.appBackground)
         }
     }
 

--- a/Budget/SummaryView.swift
+++ b/Budget/SummaryView.swift
@@ -83,15 +83,15 @@ struct SummaryView: View {
                 }
             }
             .scrollContentBackground(.hidden)
-            .background(Color.clear)
+            .background(Color.appBackground)
             .listRowBackground(Color.appSecondaryBackground)
             .navigationTitle("Summary")
         }
-        .background(Color.clear)
+        .background(Color.appBackground)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.black, for: .navigationBar)
+        .toolbarBackground(Color.appBackground, for: .navigationBar)
     }
 
     // MARK: - Filtering for selected month/year


### PR DESCRIPTION
## Summary
- remove background image storage and display logic
- centralize all screen and toolbar backgrounds to `Color.appBackground`
- keep existing fields and tab bar intact

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Budget.xcodeproj -scheme Budget -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ef69b19c8321a2d17011c968f034