### PR TITLE
Add customizable background image option

### DIFF
--- a/Budget/BackgroundImageView.swift
+++ b/Budget/BackgroundImageView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import UIKit
+
+/// Displays either the user-selected background image or the default
+/// background color. The image automatically scales to fill the screen.
+struct BackgroundImageView: View {
+    @AppStorage("backgroundImage") private var backgroundImageData: Data?
+
+    var body: some View {
+        Group {
+            if let data = backgroundImageData,
+               let uiImage = UIImage(data: data) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
+            } else {
+                Color.black.ignoresSafeArea()
+            }
+        }
+    }
+}

--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -27,7 +27,7 @@ struct BudgetApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                Color.appBackground.ignoresSafeArea()
+                BackgroundImageView()
                 RootSwitcherView()
             }
             .preferredColorScheme(.dark)

--- a/Budget/Color+Theme.swift
+++ b/Budget/Color+Theme.swift
@@ -1,7 +1,18 @@
 import SwiftUI
 
 extension Color {
-    static let appBackground = Color.black
+    /// Main background color. When a custom background image is set in
+    /// `UserDefaults` under the key `"backgroundImage"`, this becomes `clear`
+    /// so the image can be seen. Otherwise it defaults to the previous dark
+    /// background.
+    static var appBackground: Color {
+        if UserDefaults.standard.data(forKey: "backgroundImage") != nil {
+            return .clear
+        } else {
+            return .black
+        }
+    }
+
     static let appSecondaryBackground = Color(red: 27.0/255.0, green: 28.0/255.0, blue: 28.0/255.0)
     static let appAccent = Color(red: 0.0/255.0, green: 255.0/255.0, blue: 255.0/255.0)
     static let appText = Color.white

--- a/Budget/HistoryView.swift
+++ b/Budget/HistoryView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct HistoryView: View {
     @Environment(\.modelContext) private var context
+    @AppStorage("backgroundImage") private var backgroundImageData: Data?
 
     // Fetch all transactions, newest first
     @Query(sort: \Transaction.date, order: .reverse)

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -21,6 +21,8 @@ struct HomeTabView: View {
 
     @State private var selection: Tab = .input
     @Namespace private var animation
+    // Trigger view updates when background image changes
+    @AppStorage("backgroundImage") private var backgroundImageData: Data?
 
     private var contentView: some View {
         Group {

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import SwiftData
 import UIKit
+import PhotosUI
 
 // MARK: - UIKit-powered money field with a guaranteed inputAccessoryView
 struct MoneyTextField: UIViewRepresentable {
@@ -168,12 +169,23 @@ struct InputView: View {
     @State private var showSavedToast = false
     @State private var alertMessage: String?
 
+    // Background image picker
+    @AppStorage("backgroundImage") private var backgroundImageData: Data?
+    @State private var photoPickerItem: PhotosPickerItem?
+
     private let chipHeight: CGFloat = 40
 
     var body: some View {
         NavigationStack {
             formContent
                 .navigationTitle("Input")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        PhotosPicker(selection: $photoPickerItem, matching: .images) {
+                            Image(systemName: "plus")
+                        }
+                    }
+                }
         }
         .background(Color.appBackground)
         .foregroundColor(.appText)
@@ -208,6 +220,13 @@ struct InputView: View {
         }
         .overlay(alignment: .top) { toastOverlay }
         .animation(.default, value: showSavedToast)
+        .onChange(of: photoPickerItem) { newItem in
+            Task {
+                if let data = try? await newItem?.loadTransferable(type: Data.self) {
+                    backgroundImageData = data
+                }
+            }
+        }
         .alert("Oops", isPresented: alertBinding) {
             Button("OK") { alertMessage = nil }
         } message: {

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -5,6 +5,7 @@ import UIKit
 @MainActor
 struct ManageView: View {
     @Environment(\.modelContext) private var context
+    @AppStorage("backgroundImage") private var backgroundImageData: Data?
 
     init() {
         let segmented = UISegmentedControl.appearance()

--- a/Budget/SummaryView.swift
+++ b/Budget/SummaryView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct SummaryView: View {
     @Query(sort: \Transaction.date, order: .reverse)
     private var txs: [Transaction]
+    @AppStorage("backgroundImage") private var backgroundImageData: Data?
 
     // Month/Year selection (defaults to current)
     @State private var selectedMonth: Int = Calendar.current.component(.month, from: Date())


### PR DESCRIPTION
## Summary
- let users choose a background image from the Input screen via a `+` button
- show the selected image behind the app, sized to fit the screen
- make default background color transparent when an image exists

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f0cb53d48321b18fb7c9798e22d9