### PR TITLE
Fix image picker button placement

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -193,21 +193,21 @@ struct InputView: View {
         NavigationStack {
             formContent
                 .navigationTitle("Input")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            showingImagePicker = true
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                    }
+                }
         }
         .appBackground()
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(Color.appBackground, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    showingImagePicker = true
-                } label: {
-                    Image(systemName: "plus")
-                }
-            }
-        }
         .photosPicker(isPresented: $showingImagePicker, selection: $photoItem, matching: .images)
         .onChange(of: photoItem) { newItem in
             Task {


### PR DESCRIPTION
## Summary
- ensure "Input" screen shows a plus button in the top-right toolbar to trigger the image picker

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f8a3f2988321a021923fc82d0c19