### PR TITLE
Ensure background image persists across tabs

### DIFF
--- a/Budget/HistoryView.swift
+++ b/Budget/HistoryView.swift
@@ -78,7 +78,7 @@ struct HistoryView: View {
             .navigationTitle("History")
             .toolbar { EditButton() } // enables swipe-to-delete / Edit
         }
-        .appBackground()
+        .background(Color.clear)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -32,7 +32,6 @@ struct HomeTabView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .appBackground()
     }
 
     private var tabBar: some View {
@@ -108,6 +107,7 @@ struct HomeTabView: View {
             contentView
             tabBar
         }
+        .appBackground()
         .ignoresSafeArea(.all, edges: .bottom)
     }
 }

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -203,7 +203,7 @@ struct InputView: View {
                     }
                 }
         }
-        .appBackground()
+        .background(Color.clear)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -63,7 +63,7 @@ struct ManageView: View {
                 Text(alertMessage ?? "")
             }
         }
-        .appBackground()
+        .background(Color.clear)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)

--- a/Budget/SummaryView.swift
+++ b/Budget/SummaryView.swift
@@ -87,7 +87,7 @@ struct SummaryView: View {
             .listRowBackground(Color.appSecondaryBackground)
             .navigationTitle("Summary")
         }
-        .appBackground()
+        .background(Color.clear)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- Display global background image from HomeTabView so it stays visible when switching tabs
- Remove per-view background overlays and make NavigationStacks transparent to avoid black screens

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fad140788321b477f35871578b8c