### PR TITLE
Ensure background image persists across tabs

### DIFF
--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -33,10 +33,13 @@ struct BudgetApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootSwitcherView()
-                .preferredColorScheme(.dark)
-                .tint(.appAccent)
-                .environmentObject(bgStore)
+            ZStack {
+                AppBackgroundView()
+                RootSwitcherView()
+            }
+            .preferredColorScheme(.dark)
+            .tint(.appAccent)
+            .environmentObject(bgStore)
         }
         .modelContainer(for: [Transaction.self, Category.self, PaymentMethod.self])
     }

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -107,7 +107,6 @@ struct HomeTabView: View {
             contentView
             tabBar
         }
-        .appBackground()
         .ignoresSafeArea(.all, edges: .bottom)
     }
 }

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -17,7 +17,6 @@ struct RootSwitcherView: View {
             try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
             showSplash = false
         }
-        .appBackground()
     }
 }
 


### PR DESCRIPTION
## Summary
- Display the selected image as a single global background by layering `AppBackgroundView` at the app root
- Remove per-view background overlays that masked the image when switching tabs

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fc61cf088321ba3d77ab995dda07