### PR TITLE
Ensure background image updates on main thread

### DIFF
--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -213,7 +213,9 @@ struct InputView: View {
             Task {
                 if let data = try? await newItem?.loadTransferable(type: Data.self),
                    let uiImage = UIImage(data: data) {
-                    bgStore.image = processImage(uiImage)
+                    await MainActor.run {
+                        bgStore.image = processImage(uiImage)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- update photo selection handler to assign background image on main thread

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fe6e28c48321af9cd9694d705a93