### PR TITLE
Fix background image sizing

### DIFF
--- a/Budget/AppBackgroundView.swift
+++ b/Budget/AppBackgroundView.swift
@@ -9,11 +9,12 @@ struct AppBackgroundView: View {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFill()
-                    .clipped()
             } else {
                 Color.appBackground
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
         .ignoresSafeArea()
     }
 }


### PR DESCRIPTION
## Summary
- expand background image to fill full screen and ignore safe area

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c50168dda88321ac197e7344dc34a4