### PR TITLE
Fix background image overlay

### DIFF
--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -108,5 +108,6 @@ struct HomeTabView: View {
             tabBar
         }
         .ignoresSafeArea(.all, edges: .bottom)
+        .background(Color.clear)
     }
 }

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -12,6 +12,7 @@ struct RootSwitcherView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: showSplash)
+        .background(Color.clear)
         .task {
             // Simulate small load, then switch to Home
             try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second


### PR DESCRIPTION
## Summary
- Ensure tab container and root switcher have clear backgrounds so background image remains visible

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c502c245a88321b96431c0a30f7662