### PR TITLE
Fix disappearing background image across tabs

### DIFF
--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -12,8 +12,8 @@ struct BudgetApp: App {
     @StateObject private var bgStore = BackgroundImageStore()
     init() {
         let appearance = UINavigationBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor(Color.appBackground)
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .clear
         appearance.titleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         appearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         UINavigationBar.appearance().standardAppearance = appearance
@@ -21,7 +21,7 @@ struct BudgetApp: App {
         UINavigationBar.appearance().compactAppearance = appearance
 
         let segmented = UISegmentedControl.appearance()
-        segmented.backgroundColor = UIColor(Color.appBackground)
+        segmented.backgroundColor = .clear
         segmented.selectedSegmentTintColor = UIColor(Color.appAccent)
         segmented.setTitleTextAttributes([
             .foregroundColor: UIColor(Color.appText)
@@ -33,13 +33,11 @@ struct BudgetApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                AppBackgroundView()
-                RootSwitcherView()
-            }
-            .preferredColorScheme(.dark)
-            .tint(.appAccent)
-            .environmentObject(bgStore)
+            RootSwitcherView()
+                .background(AppBackgroundView())
+                .preferredColorScheme(.dark)
+                .tint(.appAccent)
+                .environmentObject(bgStore)
         }
         .modelContainer(for: [Transaction.self, Category.self, PaymentMethod.self])
     }

--- a/Budget/HistoryView.swift
+++ b/Budget/HistoryView.swift
@@ -82,7 +82,7 @@ struct HistoryView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.clear, for: .navigationBar)
     }
 
     // MARK: - Helpers

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -207,7 +207,7 @@ struct InputView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.clear, for: .navigationBar)
         .photosPicker(isPresented: $showingImagePicker, selection: $photoItem, matching: .images)
         .onChange(of: photoItem) { newItem in
             Task {

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -67,7 +67,7 @@ struct ManageView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.clear, for: .navigationBar)
         .sheet(isPresented: $showCategoryForm) {
             CategoryFormSheet(
                 newCategory: $newCategory,

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -11,6 +11,7 @@ struct RootSwitcherView: View {
                 HomeTabView()
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.easeInOut(duration: 0.3), value: showSplash)
         .background(Color.clear)
         .task {

--- a/Budget/SummaryView.swift
+++ b/Budget/SummaryView.swift
@@ -91,7 +91,7 @@ struct SummaryView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.appBackground, for: .navigationBar)
+        .toolbarBackground(Color.clear, for: .navigationBar)
     }
 
     // MARK: - Filtering for selected month/year


### PR DESCRIPTION
## Summary
- Inject global background view and remove dark navigation bar so selected photo shows across all tabs
- Expand RootSwitcherView to full screen and clear toolbar backgrounds for each view

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c504e3a3288321ac5a011c38a86e6a