### PR TITLE
Make navigation and list views translucent for background image

### DIFF
--- a/Budget/AppBackgroundView.swift
+++ b/Budget/AppBackgroundView.swift
@@ -16,6 +16,7 @@ struct AppBackgroundView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipped()
         .ignoresSafeArea()
+        .allowsHitTesting(false)
     }
 }
 

--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -13,6 +13,7 @@ struct BudgetApp: App {
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .systemThinMaterialDark)
         appearance.backgroundColor = .clear
         appearance.titleTextAttributes = [.foregroundColor: UIColor(Color.appText)]
         appearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.appText)]

--- a/Budget/HistoryView.swift
+++ b/Budget/HistoryView.swift
@@ -24,22 +24,26 @@ struct HistoryView: View {
                 } else {
                     // Monthly total section (current month)
                     Section("This month") {
-                        HStack {
-                            Text("Income")
-                            Spacer()
-                            Text(incomeThisMonth as NSNumber, formatter: currencyFormatter)
+                        Group {
+                            HStack {
+                                Text("Income")
+                                Spacer()
+                                Text(incomeThisMonth as NSNumber, formatter: currencyFormatter)
+                            }
+                            HStack {
+                                Text("Expenses")
+                                Spacer()
+                                Text(expensesThisMonth as NSNumber, formatter: currencyFormatter)
+                            }
+                            HStack {
+                                Text("Net")
+                                Spacer()
+                                Text(netThisMonth as NSNumber, formatter: currencyFormatter)
+                                    .fontWeight(.semibold)
+                            }
                         }
-                        HStack {
-                            Text("Expenses")
-                            Spacer()
-                            Text(expensesThisMonth as NSNumber, formatter: currencyFormatter)
-                        }
-                        HStack {
-                            Text("Net")
-                            Spacer()
-                            Text(netThisMonth as NSNumber, formatter: currencyFormatter)
-                                .fontWeight(.semibold)
-                        }
+                        .padding(12)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
                     }
 
                     // All transactions
@@ -67,14 +71,17 @@ struct HistoryView: View {
                                 .foregroundColor(Color.appText.opacity(0.6))
                                 .font(.caption)
                             }
+                            .padding(12)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
                         }
                         .onDelete(perform: delete)
                     }
                 }
             }
+            .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .background(Color.clear)
-            .listRowBackground(Color.appSecondaryBackground)
+            .listRowBackground(Color.clear)
             .navigationTitle("History")
             .toolbar { EditButton() } // enables swipe-to-delete / Edit
         }
@@ -82,7 +89,6 @@ struct HistoryView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.clear, for: .navigationBar)
     }
 
     // MARK: - Helpers

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -173,19 +173,6 @@ struct InputView: View {
     @State private var showingImagePicker = false
     @State private var photoItem: PhotosPickerItem?
 
-    private func processImage(_ image: UIImage) -> UIImage {
-        let screen = UIScreen.main.bounds.size
-        let scale = max(screen.width / image.size.width, screen.height / image.size.height)
-        let newSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
-        let renderer = UIGraphicsImageRenderer(size: screen)
-        return renderer.image { _ in
-            image.draw(in: CGRect(x: (screen.width - newSize.width) / 2,
-                                  y: (screen.height - newSize.height) / 2,
-                                  width: newSize.width,
-                                  height: newSize.height))
-        }
-    }
-
 
     private let chipHeight: CGFloat = 40
 
@@ -207,15 +194,12 @@ struct InputView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.clear, for: .navigationBar)
         .photosPicker(isPresented: $showingImagePicker, selection: $photoItem, matching: .images)
         .onChange(of: photoItem) { newItem in
             Task {
                 if let data = try? await newItem?.loadTransferable(type: Data.self),
                    let uiImage = UIImage(data: data) {
-                    await MainActor.run {
-                        bgStore.image = processImage(uiImage)
-                    }
+                    await MainActor.run { bgStore.image = uiImage }
                 }
             }
         }

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -45,7 +45,8 @@ struct ManageView: View {
             }
             .scrollContentBackground(.hidden)
             .background(Color.clear)
-            .listRowBackground(Color.appSecondaryBackground)
+            .listRowBackground(Color.clear)
+            .listStyle(.grouped)
             .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Manage")
             .toolbar {
@@ -67,7 +68,6 @@ struct ManageView: View {
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.clear, for: .navigationBar)
         .sheet(isPresented: $showCategoryForm) {
             CategoryFormSheet(
                 newCategory: $newCategory,

--- a/Budget/SummaryView.swift
+++ b/Budget/SummaryView.swift
@@ -82,16 +82,16 @@ struct SummaryView: View {
                     }
                 }
             }
+            .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .background(Color.clear)
-            .listRowBackground(Color.appSecondaryBackground)
+            .listRowBackground(Color.clear)
             .navigationTitle("Summary")
         }
         .background(Color.clear)
         .foregroundColor(.appText)
         .tint(.appAccent)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color.clear, for: .navigationBar)
     }
 
     // MARK: - Filtering for selected month/year


### PR DESCRIPTION
## Summary
- Blur and clear global navigation bar so the background image shows through
- Allow background image view to ignore touches and load full-resolution photos
- Remove opaque list/form backgrounds and use optional glass cards for history rows

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5070be69883219c258af8a0f0b078