### PR TITLE
Move app background to window layer

### DIFF
--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -34,11 +34,13 @@ struct BudgetApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootSwitcherView()
-                .background(AppBackgroundView())
-                .preferredColorScheme(.dark)
-                .tint(.appAccent)
-                .environmentObject(bgStore)
+            ZStack {
+                AppBackgroundView()
+                RootSwitcherView()
+            }
+            .preferredColorScheme(.dark)
+            .tint(.appAccent)
+            .environmentObject(bgStore)
         }
         .modelContainer(for: [Transaction.self, Category.self, PaymentMethod.self])
     }


### PR DESCRIPTION
## Summary
- Layer AppBackgroundView beneath the app content using a ZStack in BudgetApp
- Remove background modifier from RootSwitcherView invocation to avoid rebuild flicker

## Testing
- ⚠️ `swift test` *(Package.swift not found; project uses Xcode project)*

------
https://chatgpt.com/codex/tasks/task_e_68c50912f55c83218427327bd926fe74