### PR TITLE
Unify background image handling with global store

### DIFF
--- a/Budget/AppBackgroundView.swift
+++ b/Budget/AppBackgroundView.swift
@@ -5,23 +5,15 @@ struct AppBackgroundView: View {
 
     var body: some View {
         Group {
-            if let image = store.image {
-                Image(uiImage: image)
+            if let ui = store.image {
+                Image(uiImage: ui)
                     .resizable()
                     .scaledToFill()
             } else {
                 Color.appBackground
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .clipped()
         .ignoresSafeArea()
         .allowsHitTesting(false)
-    }
-}
-
-extension View {
-    func appBackground() -> some View {
-        background(AppBackgroundView())
     }
 }

--- a/Budget/BackgroundImageStore.swift
+++ b/Budget/BackgroundImageStore.swift
@@ -1,6 +1,6 @@
 import SwiftUI
-import UIKit
 
-class BackgroundImageStore: ObservableObject {
-    @Published var image: UIImage?
+@MainActor
+final class BackgroundImageStore: ObservableObject {
+    @Published var image: UIImage? = nil
 }

--- a/Budget/BudgetApp.swift
+++ b/Budget/BudgetApp.swift
@@ -9,7 +9,7 @@ let SHEETS = SheetsClient(
 
 @main
 struct BudgetApp: App {
-    @StateObject private var bgStore = BackgroundImageStore()
+    @StateObject private var bgStore = BackgroundImageStore()   // <- single source of truth
     init() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
@@ -35,12 +35,12 @@ struct BudgetApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                AppBackgroundView()
-                RootSwitcherView()
+                AppBackgroundView()     // always-present base layer
+                RootSwitcherView()      // your entire app on top
             }
+            .environmentObject(bgStore) // inject ONCE at the root
             .preferredColorScheme(.dark)
             .tint(.appAccent)
-            .environmentObject(bgStore)
         }
         .modelContainer(for: [Transaction.self, Category.self, PaymentMethod.self])
     }

--- a/Budget/ContentView.swift
+++ b/Budget/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
                 .foregroundColor(.appText)
         }
         .padding()
-        .appBackground()
+        .background(Color.clear)
     }
 }
 

--- a/Budget/InputView.swift
+++ b/Budget/InputView.swift
@@ -149,7 +149,7 @@ struct AccessoryTextField: UIViewRepresentable {
 @MainActor
 struct InputView: View {
     @Environment(\.modelContext) private var context
-    @EnvironmentObject private var bgStore: BackgroundImageStore
+    @EnvironmentObject private var store: BackgroundImageStore
 
     @Query(sort: [
         SortDescriptor(\Category.sortIndex, order: .forward),
@@ -182,8 +182,13 @@ struct InputView: View {
                 .navigationTitle("Input")
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
-                        Button {
-                            showingImagePicker = true
+                        Menu {
+                            Button("Choose Background") {
+                                showingImagePicker = true
+                            }
+                            Button("Remove Background") {
+                                store.image = nil
+                            }
                         } label: {
                             Image(systemName: "plus")
                         }
@@ -199,7 +204,7 @@ struct InputView: View {
             Task {
                 if let data = try? await newItem?.loadTransferable(type: Data.self),
                    let uiImage = UIImage(data: data) {
-                    await MainActor.run { bgStore.image = uiImage }
+                    await MainActor.run { store.image = uiImage }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Refactor `BackgroundImageStore` into a `@MainActor` singleton-style `ObservableObject`
- Inject the background store once at the app root and pin `AppBackgroundView` behind all content
- Update views to use the environment store for choosing or clearing the background image and remove per-view background modifier

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project Budget.xcodeproj -scheme Budget test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50a44e85883218bec8563e77fef17