### PR TITLE
Restore “+” background picker button as a global overlay (keeps chips & tab bar unchanged)

### DIFF
--- a/Budget/BackgroundAddButton.swift
+++ b/Budget/BackgroundAddButton.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import PhotosUI
+
+struct BackgroundAddButton: View {
+    @EnvironmentObject private var store: BackgroundImageStore
+    @State private var item: PhotosPickerItem?
+
+    var body: some View {
+        PhotosPicker(selection: $item, matching: .images, photoLibrary: .shared()) {
+            // Circular “+” with material background
+            Image(systemName: "plus.circle.fill")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(12)
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 1))
+                .shadow(radius: 8)
+        }
+        .accessibilityLabel("Add Background Image")
+        // Use both onChange and task(id:) so selection always processes
+        .onChange(of: item) { oldValue, newValue in
+            Task { await loadSelection(newValue) }
+        }
+        .task(id: item) {
+            await loadSelection(item)
+        }
+    }
+
+    private func loadSelection(_ selection: PhotosPickerItem?) async {
+        guard let selection else { return }
+        do {
+            if let data = try await selection.loadTransferable(type: Data.self),
+               let img  = UIImage(data: data) {
+                await MainActor.run { store.setImage(img) }
+            }
+        } catch {
+            // ignore failures; keep previous background
+        }
+    }
+}
+

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -103,11 +103,25 @@ struct HomeTabView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            contentView
-            tabBar
+        ZStack {
+            ZStack(alignment: .bottom) {
+                contentView
+                tabBar
+            }
+            .ignoresSafeArea(.all, edges: .bottom)
+            .background(Color.clear)
+
+            VStack {
+                HStack {
+                    Spacer()
+                    BackgroundAddButton()
+                        .padding(.trailing, 16)
+                }
+                .padding(.top, 8)
+
+                Spacer()
+            }
+            .allowsHitTesting(true)
         }
-        .ignoresSafeArea(.all, edges: .bottom)
-        .background(Color.clear)
     }
 }


### PR DESCRIPTION
## Summary
- add reusable `BackgroundAddButton` for picking new background images
- overlay `BackgroundAddButton` on top of all tabs without touching existing chips or tab bar

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c51606d51c83218fc58fa75caab0b2