### PR TITLE
Stop screens from covering the window background (remove opaque layers; keep all functionality)

### DIFF
--- a/Budget/AppAppearance.swift
+++ b/Budget/AppAppearance.swift
@@ -6,8 +6,9 @@ enum AppAppearance {
         UITableViewCell.appearance().backgroundColor = .clear
         UICollectionView.appearance().backgroundColor = .clear
         UIScrollView.appearance().backgroundColor = .clear
-        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
-        UINavigationBar.appearance().shadowImage = UIImage()
-        UINavigationBar.appearance().isTranslucent = true
+        let nav = UINavigationBar.appearance()
+        nav.setBackgroundImage(UIImage(), for: .default)
+        nav.shadowImage = UIImage()
+        nav.isTranslucent = true
     }
 }

--- a/Budget/BackgroundAddButton.swift
+++ b/Budget/BackgroundAddButton.swift
@@ -24,11 +24,7 @@ struct BackgroundAddButton: View {
         .task(id: pickerItem) {
             await loadSelection(pickerItem)
         }
-    }
-
-    @MainActor
-    private func setBackground(_ ui: UIImage?) {
-        store.setImage(ui)
+        .background(Color.clear)
     }
 
     private func loadSelection(_ item: PhotosPickerItem?) async {
@@ -36,7 +32,7 @@ struct BackgroundAddButton: View {
         do {
             if let data = try await item.loadTransferable(type: Data.self),
                let ui   = UIImage(data: data) {
-                await MainActor.run { setBackground(ui) }
+                await MainActor.run { store.setImage(ui) }
             }
         } catch {
             // ignore failures

--- a/Budget/Color+AppBackground.swift
+++ b/Budget/Color+AppBackground.swift
@@ -1,0 +1,4 @@
+import SwiftUI
+extension Color {
+    static var appBackground: Color { .clear }
+}

--- a/Budget/Color+Theme.swift
+++ b/Budget/Color+Theme.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 extension Color {
-    static let appBackground = Color(red: 0/255, green: 0/255, blue: 0/255)
     static let appSecondaryBackground = Color(red: 27/255, green: 28/255, blue: 28/255)
     static let appTabBar = Color(red: 49/255, green: 50/255, blue: 50/255)
     static let appAccent = Color(red: 255/255, green: 255/255, blue: 255/255)

--- a/Budget/HomeTabView.swift
+++ b/Budget/HomeTabView.swift
@@ -123,5 +123,6 @@ struct HomeTabView: View {
             }
             .allowsHitTesting(true)
         }
+        .background(Color.clear)
     }
 }

--- a/Budget/ManageView.swift
+++ b/Budget/ManageView.swift
@@ -324,17 +324,12 @@ struct ManageView: View {
     }
 
     // MARK: - Helpers
-    @MainActor
-    private func setBackground(_ ui: UIImage?) {
-        store.setImage(ui)
-    }
-
     private func loadSelection(_ item: PhotosPickerItem?) async {
         guard let item else { return }
         do {
             if let data = try await item.loadTransferable(type: Data.self),
                let ui = UIImage(data: data) {
-                await MainActor.run { setBackground(ui) }
+                await MainActor.run { store.setImage(ui) }
             }
         } catch {
             // Ignore; keep previous background
@@ -396,6 +391,7 @@ private struct CategoryFormSheet: View {
             .disabled(newCategory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .padding()
+        .background(Color.clear)
     }
 }
 
@@ -430,6 +426,7 @@ private struct PaymentFormSheet: View {
             .disabled(newPayment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .padding()
+        .background(Color.clear)
     }
 }
 

--- a/Budget/RootSwitcherView.swift
+++ b/Budget/RootSwitcherView.swift
@@ -35,5 +35,6 @@ struct SplashView: View {
             .foregroundColor(.appText)
         }
         .ignoresSafeArea()
+        .background(Color.clear)
     }
 }

--- a/Budget/WindowBackgroundView.swift
+++ b/Budget/WindowBackgroundView.swift
@@ -14,7 +14,7 @@ struct WindowBackgroundView: View {
                         .frame(width: size.width, height: size.height)
                         .clipped()
                 } else {
-                    Color.black  // fallback
+                    Color.black
                 }
             }
             .frame(width: size.width, height: size.height)


### PR DESCRIPTION
## Summary
- Centralize window background handling in a single `BackgroundImageStore` and route image pickers through the shared store
- Remove opaque view backgrounds and ensure top-level containers and sheets remain transparent
- Make UIKit containers and `Color.appBackground` fully transparent for consistent window-level imagery

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c58aa6a74c8321aca12e728649c55e