### PR TITLE
Use UIKit emoji text field with SwiftUI wrapper

### DIFF
--- a/Budget/Styles/KeyboardManager.swift
+++ b/Budget/Styles/KeyboardManager.swift
@@ -1,4 +1,113 @@
 import SwiftUI
+import UIKit
+
+// MARK: - UIKit Emoji Text Field
+final class EmojiTextField: UITextField {
+    override var textInputContextIdentifier: String? {
+        ""
+    }
+
+    override var textInputMode: UITextInputMode? {
+        if let emojiMode = UITextInputMode.activeInputModes.first(where: { $0.primaryLanguage == "emoji" }) {
+            return emojiMode
+        }
+        return super.textInputMode
+    }
+}
+
+// MARK: - SwiftUI Wrapper
+struct EmojiTextFieldRepresentable: UIViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+    var isFirstResponder: FocusState<Bool>.Binding
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> EmojiTextField {
+        let textField = EmojiTextField(frame: .zero)
+        textField.delegate = context.coordinator
+        textField.backgroundColor = .clear
+        textField.textColor = .white
+        textField.tintColor = .white
+        textField.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.spellCheckingType = .no
+        textField.returnKeyType = .done
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textField.addTarget(context.coordinator, action: #selector(Coordinator.textDidChange(_:)), for: .editingChanged)
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 4, height: 0))
+        textField.leftViewMode = .always
+        textField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 4, height: 0))
+        textField.rightViewMode = .always
+        applyPlaceholder(placeholder, to: textField)
+        return textField
+    }
+
+    func updateUIView(_ uiView: EmojiTextField, context: Context) {
+        context.coordinator.parent = self
+
+        if uiView.text != text {
+            uiView.text = text
+        }
+
+        applyPlaceholder(placeholder, to: uiView)
+
+        if isFirstResponder.wrappedValue {
+            if !uiView.isFirstResponder {
+                uiView.becomeFirstResponder()
+            }
+        } else if uiView.isFirstResponder {
+            uiView.resignFirstResponder()
+        }
+    }
+
+    private static func applyPlaceholder(_ placeholder: String, to textField: UITextField) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.white.withAlphaComponent(0.4)
+        ]
+        textField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: attributes)
+    }
+
+    private func applyPlaceholder(_ placeholder: String, to textField: UITextField) {
+        Self.applyPlaceholder(placeholder, to: textField)
+    }
+
+    // MARK: - Coordinator
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: EmojiTextFieldRepresentable
+
+        init(parent: EmojiTextFieldRepresentable) {
+            self.parent = parent
+        }
+
+        @objc func textDidChange(_ textField: UITextField) {
+            let newText = textField.text ?? ""
+            if parent.text != newText {
+                parent.text = newText
+            }
+        }
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            if !parent.isFirstResponder.wrappedValue {
+                parent.isFirstResponder.wrappedValue = true
+            }
+        }
+
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            if parent.isFirstResponder.wrappedValue {
+                parent.isFirstResponder.wrappedValue = false
+            }
+        }
+
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            textField.resignFirstResponder()
+            return true
+        }
+    }
+}
 
 // MARK: - KEYBOARD SYSTEM WITH NO TOOLBARS (GLOBAL TOOLBAR WILL BE ADDED ELSEWHERE)
 
@@ -137,12 +246,9 @@ struct AppEmojiField: View {
     @FocusState private var isFocused: Bool
     
     var body: some View {
-        TextField(placeholder, text: $text)
+        EmojiTextFieldRepresentable(text: $text, placeholder: placeholder, isFirstResponder: $isFocused)
             .focused($isFocused)
-            .foregroundColor(.white)
-            .keyboardType(.default)
-            .autocorrectionDisabled(true)
-            .textInputAutocapitalization(.never)
+            .frame(maxWidth: .infinity)
             .onChange(of: text) { _, newValue in
                 if newValue.count > 10 {
                     text = String(newValue.prefix(10))


### PR DESCRIPTION
## Summary
- add a UIKit-backed `EmojiTextField` subclass that forces the emoji keyboard
- wrap the UIKit field in `EmojiTextFieldRepresentable` for SwiftUI bindings
- update `AppEmojiField` to use the new representable and keep the 10-character cap

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c89de80f60832184212b9931fa5227