### PR TITLE
Fix keyboard scrolling on InputView and bottom sheets

### DIFF
--- a/Budget/Main Screens/InputView.swift
+++ b/Budget/Main Screens/InputView.swift
@@ -20,11 +20,14 @@ struct InputView: View {
     @State private var isAmountFieldFocused: Bool = false
     @State private var isDescriptionFieldFocused: Bool = false
     @State private var scrollOffset: CGFloat = 0
-    
+
     // Dynamic scroll measurement
     @State private var saveButtonFrame: CGRect = .zero
+    @State private var amountFieldFrame: CGRect = .zero
+    @State private var descriptionFieldFrame: CGRect = .zero
     @State private var scrollViewHeight: CGFloat = 0
     @State private var keyboardHeight: CGFloat = 0
+    @State private var fieldSwitchWorkItem: DispatchWorkItem?
     
     // Track focus changes to handle direct switching
     @State private var focusedField: String? = nil {
@@ -61,6 +64,17 @@ struct InputView: View {
                         ) { isFocused in
                             isDescriptionFieldFocused = isFocused
                         }
+                        .background(
+                            GeometryReader { geometry in
+                                Color.clear
+                                    .onAppear {
+                                        descriptionFieldFrame = geometry.frame(in: .global)
+                                    }
+                                    .onChange(of: geometry.frame(in: .global)) { _, newFrame in
+                                        descriptionFieldFrame = newFrame
+                                    }
+                            }
+                        )
                     }
                     
                     // Save button
@@ -96,10 +110,12 @@ struct InputView: View {
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
             if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                 keyboardHeight = keyboardFrame.height
+                handleFieldSwitch(from: focusedField, to: focusedField)
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
             keyboardHeight = 0
+            handleFieldSwitch(from: focusedField, to: focusedField)
         }
         .alert("Oops", isPresented: alertBinding) {
             Button("OK") { alertMessage = nil }
@@ -130,36 +146,66 @@ struct InputView: View {
     }
     
     private func handleFieldSwitch(from: String?, to: String?) {
-        guard to != nil else {
-            // Keyboard dismissed - reset scroll
+        fieldSwitchWorkItem?.cancel()
+
+        guard let to else {
             withAnimation(.easeInOut(duration: 0.3)) {
                 scrollOffset = 0
             }
+            fieldSwitchWorkItem = nil
             return
         }
-        
-        // Calculate dynamically based on actual positions
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            withAnimation(.easeInOut(duration: 0.3)) {
-                // Get the bottom of the save button
-                let buttonBottom = saveButtonFrame.maxY
-                
-                // Get the top of the keyboard (screen height - keyboard height)
-                let keyboardTop = UIScreen.main.bounds.height - keyboardHeight
-                
-                // Calculate how much we need to scroll
-                // We want the button to be visible above the keyboard with some padding
-                let padding: CGFloat = 20
-                let targetPosition = keyboardTop - padding
-                
-                // If button is below the target position, scroll up
-                if buttonBottom > targetPosition {
-                    scrollOffset = -(buttonBottom - targetPosition)
-                } else {
-                    // Button is already visible, no scroll needed
+
+        var workItem: DispatchWorkItem?
+        workItem = DispatchWorkItem { [weak workItem] in
+            guard let workItem, workItem.isCancelled == false else { return }
+
+            guard keyboardHeight > 0 else {
+                withAnimation(.easeInOut(duration: 0.3)) {
                     scrollOffset = 0
                 }
+                fieldSwitchWorkItem = nil
+                return
             }
+
+            let keyboardTop = UIScreen.main.bounds.height - keyboardHeight
+            let padding: CGFloat = 24
+            let targetPosition = keyboardTop - padding
+
+            let normalizedButtonBottom: CGFloat
+            if saveButtonFrame == .zero {
+                normalizedButtonBottom = 0
+            } else {
+                normalizedButtonBottom = saveButtonFrame.maxY - scrollOffset
+            }
+
+            let normalizedFieldBottom: CGFloat
+            switch to {
+            case "value":
+                normalizedFieldBottom = amountFieldFrame == .zero ? 0 : amountFieldFrame.maxY - scrollOffset
+            case "description":
+                normalizedFieldBottom = descriptionFieldFrame == .zero ? 0 : descriptionFieldFrame.maxY - scrollOffset
+            default:
+                normalizedFieldBottom = 0
+            }
+
+            let fieldOverlap = max(0, normalizedFieldBottom - targetPosition)
+            let buttonOverlap = max(0, normalizedButtonBottom - targetPosition)
+            let requiredOffset = -max(fieldOverlap, buttonOverlap)
+
+            if abs(scrollOffset - requiredOffset) > 0.1 {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    scrollOffset = requiredOffset
+                }
+            }
+
+            fieldSwitchWorkItem = nil
+        }
+
+        fieldSwitchWorkItem = workItem
+
+        if let workItem {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
         }
     }
     
@@ -306,6 +352,17 @@ struct InputView: View {
             ) { isFocused in
                 isAmountFieldFocused = isFocused
             }
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            amountFieldFrame = geometry.frame(in: .global)
+                        }
+                        .onChange(of: geometry.frame(in: .global)) { _, newFrame in
+                            amountFieldFrame = newFrame
+                        }
+                }
+            )
         }
     }
     

--- a/Budget/Main Screens/ManageView.swift
+++ b/Budget/Main Screens/ManageView.swift
@@ -110,11 +110,12 @@ struct ManageView: View {
                 buttonAction: addCategory,
                 onClose: closeCategorySheet,
                 isButtonDisabled: newCategory.isEmpty
-            ) {
+            ) { reportFocusChange in
                 CategorySheetContent(
                     name: $newCategory,
                     emoji: $newCategoryEmoji,
-                    isIncome: $newCategoryIsIncome
+                    isIncome: $newCategoryIsIncome,
+                    onFieldFocusChange: reportFocusChange
                 )
             }
         }
@@ -124,10 +125,11 @@ struct ManageView: View {
                 buttonAction: addPayment,
                 onClose: closePaymentSheet,
                 isButtonDisabled: newPayment.isEmpty
-            ) {
+            ) { reportFocusChange in
                 PaymentSheetContent(
                     name: $newPayment,
-                    emoji: $newPaymentEmoji
+                    emoji: $newPaymentEmoji,
+                    onFieldFocusChange: reportFocusChange
                 )
             }
         }
@@ -137,8 +139,11 @@ struct ManageView: View {
                 buttonAction: applyHexColor,
                 onClose: { showHexColorSheet = false },
                 isButtonDisabled: !isValidHex(hexColorInput)
-            ) {
-                HexColorSheetContent(hexInput: $hexColorInput)
+            ) { reportFocusChange in
+                HexColorSheetContent(
+                    hexInput: $hexColorInput,
+                    onFieldFocusChange: reportFocusChange
+                )
             }
         }
         // Removed toolbar - sheets handle their own toolbars

--- a/Budget/Styles/BottomSheet.swift
+++ b/Budget/Styles/BottomSheet.swift
@@ -2,27 +2,31 @@ import SwiftUI
 
 // MARK: - Reusable Bottom Sheet Component
 struct BottomSheet<SheetContent: View>: View {
-    let sheetContent: SheetContent
     let buttonTitle: String
     let buttonAction: () -> Void
     let onClose: () -> Void
     let isButtonDisabled: Bool
-    @State private var keyboardShowing = false
-    
+    let contentBuilder: (_ reportFocusChange: @escaping (String?) -> Void) -> SheetContent
+
+    @State private var scrollOffset: CGFloat = 0
+    @State private var keyboardHeight: CGFloat = 0
+    @State private var buttonFrame: CGRect = .zero
+    @State private var focusedFieldID: String?
+
     init(
         buttonTitle: String,
         buttonAction: @escaping () -> Void,
         onClose: @escaping () -> Void,
         isButtonDisabled: Bool = false,
-        @ViewBuilder content: () -> SheetContent
+        @ViewBuilder content: @escaping (_ reportFocusChange: @escaping (String?) -> Void) -> SheetContent
     ) {
         self.buttonTitle = buttonTitle
         self.buttonAction = buttonAction
         self.onClose = onClose
         self.isButtonDisabled = isButtonDisabled
-        self.sheetContent = content()
+        self.contentBuilder = content
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
             // Header section
@@ -48,26 +52,41 @@ struct BottomSheet<SheetContent: View>: View {
                 }
             )
             .frame(height: 60)
-            
-            // Content that sizes itself - NO SCROLL VIEW
-            VStack(spacing: 0) {
-                // Dynamic content
-                sheetContent
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 30)
-                
-                // Fixed button at bottom
-                Button(buttonTitle, action: buttonAction)
-                    .buttonStyle(AppButtonStyle())
-                    .disabled(isButtonDisabled)
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 50) // Simple fixed bottom padding
+
+            ScrollView {
+                VStack(spacing: 0) {
+                    // Dynamic content
+                    contentBuilder(handleFocusChange)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 30)
+
+                    // Fixed button at bottom
+                    Button(buttonTitle, action: buttonAction)
+                        .buttonStyle(AppButtonStyle())
+                        .disabled(isButtonDisabled)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 50)
+                        .background(
+                            GeometryReader { geometry in
+                                Color.clear
+                                    .onAppear {
+                                        updateButtonFrame(geometry.frame(in: .global))
+                                    }
+                                    .onChange(of: geometry.frame(in: .global)) { _, newFrame in
+                                        updateButtonFrame(newFrame)
+                                    }
+                            }
+                        )
+                }
+                .offset(y: scrollOffset)
             }
-            
-            Spacer(minLength: 0) // Push content to top
+            .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.interactively)
+
+            Spacer(minLength: 0)
         }
         .background(Color(white: 0.15))
-        .ignoresSafeArea(.keyboard) // Let SwiftUI handle keyboard automatically
+        .ignoresSafeArea(.keyboard)
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Button("Cancel") {
@@ -79,11 +98,66 @@ struct BottomSheet<SheetContent: View>: View {
                 }
             }
         }
-        // Use medium detent only
         .presentationDetents([.medium])
         .presentationBackground(Color(white: 0.15))
-        .presentationDragIndicator(.hidden) // We have our own custom indicator
+        .presentationDragIndicator(.hidden)
         .interactiveDismissDisabled(false)
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                updateKeyboardHeight(keyboardFrame.height)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            updateKeyboardHeight(0)
+        }
+    }
+
+    private func handleFocusChange(_ fieldID: String?) {
+        focusedFieldID = fieldID
+
+        if fieldID != nil || keyboardHeight == 0 {
+            adjustScrollForFocusedField()
+        }
+    }
+
+    private func updateKeyboardHeight(_ height: CGFloat) {
+        keyboardHeight = height
+        adjustScrollForFocusedField()
+    }
+
+    private func updateButtonFrame(_ newFrame: CGRect) {
+        if buttonFrame != newFrame {
+            buttonFrame = newFrame
+
+            if focusedFieldID != nil && keyboardHeight > 0 {
+                adjustScrollForFocusedField(animated: false)
+            }
+        }
+    }
+
+    private func adjustScrollForFocusedField(animated: Bool = true) {
+        guard focusedFieldID != nil, keyboardHeight > 0 else {
+            setScrollOffset(0, animated: animated)
+            return
+        }
+
+        let keyboardTop = UIScreen.main.bounds.height - keyboardHeight
+        let padding: CGFloat = 24
+        let targetPosition = keyboardTop - padding
+        let buttonBottom = buttonFrame.maxY
+        let overlap = max(0, buttonBottom - targetPosition)
+
+        setScrollOffset(-overlap, animated: animated)
+    }
+
+    private func setScrollOffset(_ newValue: CGFloat, animated: Bool) {
+        if animated {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                scrollOffset = newValue
+            }
+        } else {
+            scrollOffset = newValue
+        }
     }
     
     private func hideKeyboard() {
@@ -96,8 +170,8 @@ struct CategorySheetContent: View {
     @Binding var name: String
     @Binding var emoji: String
     @Binding var isIncome: Bool
-    @FocusState private var nameFieldFocused: Bool
-    
+    var onFieldFocusChange: (String?) -> Void = { _ in }
+
     var body: some View {
         VStack(spacing: 24) {
             // Name field
@@ -105,9 +179,15 @@ struct CategorySheetContent: View {
                 Text("Name")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.white.opacity(0.6))
-                AppTextField(text: $name, placeholder: "e.g. Food")
+                AppTextField(
+                    text: $name,
+                    placeholder: "e.g. Food",
+                    onFocusChange: { isFocused in
+                        onFieldFocusChange(isFocused ? "categoryName" : nil)
+                    }
+                )
             }
-            
+
             // Emoji field with picker button
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -119,10 +199,16 @@ struct CategorySheetContent: View {
                         emoji = selectedEmoji
                     }
                 }
-                
-                AppEmojiField(text: $emoji, placeholder: "e.g. 🍕")
+
+                AppEmojiField(
+                    text: $emoji,
+                    placeholder: "e.g. 🍕",
+                    onFocusChange: { isFocused in
+                        onFieldFocusChange(isFocused ? "categoryEmoji" : nil)
+                    }
+                )
             }
-            
+
             // Type selector
             VStack(alignment: .leading, spacing: 12) {
                 Text("Type")
@@ -152,10 +238,6 @@ struct CategorySheetContent: View {
                 }
             }
         }
-        .onAppear {
-            // Don't auto-focus to prevent unexpected scrolling
-            nameFieldFocused = false
-        }
     }
 }
 
@@ -163,8 +245,8 @@ struct CategorySheetContent: View {
 struct PaymentSheetContent: View {
     @Binding var name: String
     @Binding var emoji: String
-    @FocusState private var nameFieldFocused: Bool
-    
+    var onFieldFocusChange: (String?) -> Void = { _ in }
+
     var body: some View {
         VStack(spacing: 24) {
             // Name field
@@ -172,9 +254,15 @@ struct PaymentSheetContent: View {
                 Text("Payment Type")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.white.opacity(0.6))
-                AppTextField(text: $name, placeholder: "e.g. Credit Card, Pix")
+                AppTextField(
+                    text: $name,
+                    placeholder: "e.g. Credit Card, Pix",
+                    onFocusChange: { isFocused in
+                        onFieldFocusChange(isFocused ? "paymentName" : nil)
+                    }
+                )
             }
-            
+
             // Emoji field with picker button
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -186,13 +274,15 @@ struct PaymentSheetContent: View {
                         emoji = selectedEmoji
                     }
                 }
-                
-                AppEmojiField(text: $emoji, placeholder: "e.g. 💳")
+
+                AppEmojiField(
+                    text: $emoji,
+                    placeholder: "e.g. 💳",
+                    onFocusChange: { isFocused in
+                        onFieldFocusChange(isFocused ? "paymentEmoji" : nil)
+                    }
+                )
             }
-        }
-        .onAppear {
-            // Don't auto-focus to prevent unexpected scrolling
-            nameFieldFocused = false
         }
     }
 }
@@ -200,8 +290,8 @@ struct PaymentSheetContent: View {
 // MARK: - Hex Color Input Sheet Content
 struct HexColorSheetContent: View {
     @Binding var hexInput: String
-    @FocusState private var isFocused: Bool
-    
+    var onFieldFocusChange: (String?) -> Void = { _ in }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Hex Color Code")
@@ -212,8 +302,14 @@ struct HexColorSheetContent: View {
                 Text("#")
                     .font(.system(size: 18, weight: .medium))
                     .foregroundColor(.white.opacity(0.5))
-                
-                AppTextField(text: $hexInput, placeholder: "000000")
+
+                AppTextField(
+                    text: $hexInput,
+                    placeholder: "000000",
+                    onFocusChange: { isFocused in
+                        onFieldFocusChange(isFocused ? "hexCode" : nil)
+                    }
+                )
                     .onChange(of: hexInput) { _, newValue in
                         // Remove # if user types it
                         var cleaned = newValue.replacingOccurrences(of: "#", with: "")
@@ -248,9 +344,6 @@ struct HexColorSheetContent: View {
             }
         }
         .padding(.bottom, 30)
-        .onAppear {
-            isFocused = true
-        }
     }
 }
 

--- a/Budget/Styles/KeyboardManager.swift
+++ b/Budget/Styles/KeyboardManager.swift
@@ -272,8 +272,15 @@ struct AppTextField: View {
 struct AppEmojiField: View {
     @Binding var text: String
     let placeholder: String
+    let onFocusChange: ((Bool) -> Void)?
     @FocusState private var isFocused: Bool
-    
+
+    init(text: Binding<String>, placeholder: String, onFocusChange: ((Bool) -> Void)? = nil) {
+        self._text = text
+        self.placeholder = placeholder
+        self.onFocusChange = onFocusChange
+    }
+
     var body: some View {
         EmojiTextFieldRepresentable(text: $text, placeholder: placeholder, isFirstResponder: $isFocused)
             .focused($isFocused)
@@ -287,6 +294,9 @@ struct AppEmojiField: View {
             .padding(12)
             .background(GlassBackground(isFocused: isFocused))
             // NO TOOLBAR HERE
+            .onChange(of: isFocused) { _, newValue in
+                onFocusChange?(newValue)
+            }
     }
 }
 


### PR DESCRIPTION
## Summary
- measure InputView fields and adjust the scroll offset so the focused input and save button remain above the keyboard
- wrap BottomSheet content in a scroll view, listen for focus changes from sheet fields, and shift the button clear of the keyboard
- emit focus updates from AppEmojiField and thread focus change handlers through the sheet content views

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68c8c10cd2748321b428752001946115