### PR TITLE
Improve keyboard-aware scrolling on forms

### DIFF
--- a/Budget/Styles/BottomSheet.swift
+++ b/Budget/Styles/BottomSheet.swift
@@ -7,7 +7,7 @@ struct BottomSheet<SheetContent: View>: View {
     let buttonAction: () -> Void
     let onClose: () -> Void
     let isButtonDisabled: Bool
-    @State private var keyboardShowing = false
+    @StateObject private var keyboardScroll = KeyboardScrollCoordinator()
     
     init(
         buttonTitle: String,
@@ -48,26 +48,40 @@ struct BottomSheet<SheetContent: View>: View {
                 }
             )
             .frame(height: 60)
-            
-            // Content that sizes itself - NO SCROLL VIEW
-            VStack(spacing: 0) {
-                // Dynamic content
-                sheetContent
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 30)
-                
-                // Fixed button at bottom
-                Button(buttonTitle, action: buttonAction)
-                    .buttonStyle(AppButtonStyle())
-                    .disabled(isButtonDisabled)
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 50) // Simple fixed bottom padding
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    sheetContent
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 30)
+
+                    Button(buttonTitle, action: buttonAction)
+                        .buttonStyle(AppButtonStyle())
+                        .disabled(isButtonDisabled)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 50)
+                        .background(
+                            GeometryReader { geometry in
+                                Color.clear
+                                    .onAppear {
+                                        keyboardScroll.registerButtonFrame(geometry.frame(in: .global))
+                                    }
+                                    .onChange(of: geometry.frame(in: .global)) { _, newFrame in
+                                        keyboardScroll.registerButtonFrame(newFrame)
+                                    }
+                            }
+                        )
+
+                    Spacer()
+                        .frame(height: 160)
+                }
+                .offset(y: keyboardScroll.scrollOffset)
             }
-            
-            Spacer(minLength: 0) // Push content to top
+            .scrollDismissesKeyboard(.interactively)
         }
         .background(Color(white: 0.15))
-        .ignoresSafeArea(.keyboard) // Let SwiftUI handle keyboard automatically
+        .ignoresSafeArea(.keyboard)
+        .environment(\.keyboardScrollCoordinator, keyboardScroll)
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Button("Cancel") {
@@ -84,6 +98,14 @@ struct BottomSheet<SheetContent: View>: View {
         .presentationBackground(Color(white: 0.15))
         .presentationDragIndicator(.hidden) // We have our own custom indicator
         .interactiveDismissDisabled(false)
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+            if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                keyboardScroll.keyboardWillShow(height: keyboardFrame.height)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            keyboardScroll.keyboardWillHide()
+        }
     }
     
     private func hideKeyboard() {
@@ -96,7 +118,7 @@ struct CategorySheetContent: View {
     @Binding var name: String
     @Binding var emoji: String
     @Binding var isIncome: Bool
-    @FocusState private var nameFieldFocused: Bool
+    @Environment(\.keyboardScrollCoordinator) private var keyboardScrollCoordinator
     
     var body: some View {
         VStack(spacing: 24) {
@@ -105,7 +127,13 @@ struct CategorySheetContent: View {
                 Text("Name")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.white.opacity(0.6))
-                AppTextField(text: $name, placeholder: "e.g. Food")
+                AppTextField(text: $name, placeholder: "e.g. Food") { isFocused in
+                    keyboardScrollCoordinator?.focusChanged(
+                        field: "category_name",
+                        isFocused: isFocused,
+                        accessoryHeight: KeyboardScrollCoordinator.standardAccessoryHeight
+                    )
+                }
             }
             
             // Emoji field with picker button
@@ -120,7 +148,13 @@ struct CategorySheetContent: View {
                     }
                 }
                 
-                AppEmojiField(text: $emoji, placeholder: "e.g. 🍕")
+                AppEmojiField(text: $emoji, placeholder: "e.g. 🍕") { isFocused in
+                    keyboardScrollCoordinator?.focusChanged(
+                        field: "category_emoji",
+                        isFocused: isFocused,
+                        accessoryHeight: KeyboardScrollCoordinator.emojiAccessoryHeight
+                    )
+                }
             }
             
             // Type selector
@@ -152,10 +186,6 @@ struct CategorySheetContent: View {
                 }
             }
         }
-        .onAppear {
-            // Don't auto-focus to prevent unexpected scrolling
-            nameFieldFocused = false
-        }
     }
 }
 
@@ -163,8 +193,8 @@ struct CategorySheetContent: View {
 struct PaymentSheetContent: View {
     @Binding var name: String
     @Binding var emoji: String
-    @FocusState private var nameFieldFocused: Bool
-    
+    @Environment(\.keyboardScrollCoordinator) private var keyboardScrollCoordinator
+
     var body: some View {
         VStack(spacing: 24) {
             // Name field
@@ -172,9 +202,15 @@ struct PaymentSheetContent: View {
                 Text("Payment Type")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.white.opacity(0.6))
-                AppTextField(text: $name, placeholder: "e.g. Credit Card, Pix")
+                AppTextField(text: $name, placeholder: "e.g. Credit Card, Pix") { isFocused in
+                    keyboardScrollCoordinator?.focusChanged(
+                        field: "payment_name",
+                        isFocused: isFocused,
+                        accessoryHeight: KeyboardScrollCoordinator.standardAccessoryHeight
+                    )
+                }
             }
-            
+
             // Emoji field with picker button
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -186,13 +222,15 @@ struct PaymentSheetContent: View {
                         emoji = selectedEmoji
                     }
                 }
-                
-                AppEmojiField(text: $emoji, placeholder: "e.g. 💳")
+
+                AppEmojiField(text: $emoji, placeholder: "e.g. 💳") { isFocused in
+                    keyboardScrollCoordinator?.focusChanged(
+                        field: "payment_emoji",
+                        isFocused: isFocused,
+                        accessoryHeight: KeyboardScrollCoordinator.emojiAccessoryHeight
+                    )
+                }
             }
-        }
-        .onAppear {
-            // Don't auto-focus to prevent unexpected scrolling
-            nameFieldFocused = false
         }
     }
 }
@@ -200,7 +238,7 @@ struct PaymentSheetContent: View {
 // MARK: - Hex Color Input Sheet Content
 struct HexColorSheetContent: View {
     @Binding var hexInput: String
-    @FocusState private var isFocused: Bool
+    @Environment(\.keyboardScrollCoordinator) private var keyboardScrollCoordinator
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -213,7 +251,13 @@ struct HexColorSheetContent: View {
                     .font(.system(size: 18, weight: .medium))
                     .foregroundColor(.white.opacity(0.5))
                 
-                AppTextField(text: $hexInput, placeholder: "000000")
+                AppTextField(text: $hexInput, placeholder: "000000") { isFocused in
+                    keyboardScrollCoordinator?.focusChanged(
+                        field: "hex_input",
+                        isFocused: isFocused,
+                        accessoryHeight: KeyboardScrollCoordinator.standardAccessoryHeight
+                    )
+                }
                     .onChange(of: hexInput) { _, newValue in
                         // Remove # if user types it
                         var cleaned = newValue.replacingOccurrences(of: "#", with: "")
@@ -248,9 +292,6 @@ struct HexColorSheetContent: View {
             }
         }
         .padding(.bottom, 30)
-        .onAppear {
-            isFocused = true
-        }
     }
 }
 

--- a/Budget/Styles/KeyboardManager.swift
+++ b/Budget/Styles/KeyboardManager.swift
@@ -272,8 +272,15 @@ struct AppTextField: View {
 struct AppEmojiField: View {
     @Binding var text: String
     let placeholder: String
+    let onFocusChange: ((Bool) -> Void)?
     @FocusState private var isFocused: Bool
-    
+
+    init(text: Binding<String>, placeholder: String, onFocusChange: ((Bool) -> Void)? = nil) {
+        self._text = text
+        self.placeholder = placeholder
+        self.onFocusChange = onFocusChange
+    }
+
     var body: some View {
         EmojiTextFieldRepresentable(text: $text, placeholder: placeholder, isFirstResponder: $isFocused)
             .focused($isFocused)
@@ -283,6 +290,9 @@ struct AppEmojiField: View {
                 if newValue.count > 10 {
                     text = String(newValue.prefix(10))
                 }
+            }
+            .onChange(of: isFocused) { _, newValue in
+                onFocusChange?(newValue)
             }
             .padding(12)
             .background(GlassBackground(isFocused: isFocused))

--- a/Budget/Styles/KeyboardScrollCoordinator.swift
+++ b/Budget/Styles/KeyboardScrollCoordinator.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import Combine
+
+@MainActor
+final class KeyboardScrollCoordinator: ObservableObject {
+    struct ActiveField {
+        let id: String
+        let accessoryHeight: CGFloat
+    }
+
+    static let standardAccessoryHeight: CGFloat = 44
+    static let emojiAccessoryHeight: CGFloat = 56
+
+    @Published private(set) var scrollOffset: CGFloat = 0
+
+    private let basePadding: CGFloat
+    private var keyboardHeight: CGFloat = 0
+    private var buttonFrame: CGRect = .zero
+    private var activeField: ActiveField?
+    private var resetWorkItem: DispatchWorkItem?
+    private var updateWorkItem: DispatchWorkItem?
+
+    init(basePadding: CGFloat = 20) {
+        self.basePadding = basePadding
+    }
+
+    func registerButtonFrame(_ frame: CGRect) {
+        buttonFrame = frame
+        scheduleUpdate(delayed: true)
+    }
+
+    func keyboardWillShow(height: CGFloat) {
+        keyboardHeight = height
+        scheduleUpdate(delayed: false)
+    }
+
+    func keyboardWillHide() {
+        keyboardHeight = 0
+        activeField = nil
+        cancelResetWorkItem()
+        cancelUpdateWorkItem()
+
+        withAnimation(.easeInOut(duration: 0.3)) {
+            scrollOffset = 0
+        }
+    }
+
+    func focusChanged(field id: String, isFocused: Bool, accessoryHeight: CGFloat = KeyboardScrollCoordinator.standardAccessoryHeight) {
+        if isFocused {
+            activeField = ActiveField(id: id, accessoryHeight: accessoryHeight)
+            cancelResetWorkItem()
+            scheduleUpdate(delayed: true)
+        } else if activeField?.id == id {
+            activeField = nil
+            scheduleReset()
+        }
+    }
+
+    private func scheduleUpdate(delayed: Bool) {
+        cancelUpdateWorkItem()
+        guard keyboardHeight > 0, buttonFrame != .zero, activeField != nil else { return }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, let activeField = self.activeField else { return }
+
+            let keyboardTop = UIScreen.main.bounds.height - self.keyboardHeight
+            let target = keyboardTop - (self.basePadding + activeField.accessoryHeight)
+            let buttonBottom = self.buttonFrame.maxY
+            let offset = buttonBottom > target ? -(buttonBottom - target) : 0
+
+            withAnimation(.easeInOut(duration: 0.3)) {
+                self.scrollOffset = offset
+            }
+        }
+
+        updateWorkItem = workItem
+        let delay = delayed ? 0.05 : 0
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func scheduleReset() {
+        cancelResetWorkItem()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.activeField == nil else { return }
+            withAnimation(.easeInOut(duration: 0.3)) {
+                self.scrollOffset = 0
+            }
+        }
+
+        resetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: workItem)
+    }
+
+    private func cancelResetWorkItem() {
+        resetWorkItem?.cancel()
+        resetWorkItem = nil
+    }
+
+    private func cancelUpdateWorkItem() {
+        updateWorkItem?.cancel()
+        updateWorkItem = nil
+    }
+}
+
+private struct KeyboardScrollCoordinatorKey: EnvironmentKey {
+    static let defaultValue: KeyboardScrollCoordinator? = nil
+}
+
+extension EnvironmentValues {
+    var keyboardScrollCoordinator: KeyboardScrollCoordinator? {
+        get { self[KeyboardScrollCoordinatorKey.self] }
+        set { self[KeyboardScrollCoordinatorKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `KeyboardScrollCoordinator` to keep buttons above the keyboard with consistent padding
- update the main input flow to rely on the coordinator for focus changes and keyboard notifications
- rework bottom sheets and their form fields to use the shared coordinator and report focus changes

## Testing
- xcodebuild -project Budget.xcodeproj -scheme Budget -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c8068a948321ac3640dfdddc1105